### PR TITLE
Rename 'github.com/go418/klone' to 'github.com/cert-manager/klone'

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"path/filepath"
 
-	"github.com/go418/klone/pkg/mod"
+	"github.com/cert-manager/klone/pkg/mod"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"path/filepath"
 
-	"github.com/go418/klone/pkg/mod"
+	"github.com/cert-manager/klone/pkg/mod"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -5,9 +5,9 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/go418/klone/pkg/cache"
-	"github.com/go418/klone/pkg/download/git"
-	"github.com/go418/klone/pkg/mod"
+	"github.com/cert-manager/klone/pkg/cache"
+	"github.com/cert-manager/klone/pkg/download/git"
+	"github.com/cert-manager/klone/pkg/mod"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -5,9 +5,9 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/go418/klone/pkg/cache"
-	"github.com/go418/klone/pkg/download/git"
-	"github.com/go418/klone/pkg/mod"
+	"github.com/cert-manager/klone/pkg/cache"
+	"github.com/cert-manager/klone/pkg/download/git"
+	"github.com/cert-manager/klone/pkg/mod"
 	"github.com/spf13/cobra"
 )
 

--- a/download_latest_checksum.sh
+++ b/download_latest_checksum.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 
-wget -O checksums.txt https://github.com/go418/klone/releases/download/latest/checksums.txt
-wget -O checksums.txt.cosign.bundle https://github.com/go418/klone/releases/download/latest/checksums.txt.cosign.bundle
+wget -O checksums.txt https://github.com/cert-manager/klone/releases/download/latest/checksums.txt
+wget -O checksums.txt.cosign.bundle https://github.com/cert-manager/klone/releases/download/latest/checksums.txt.cosign.bundle
 
 cosign verify-blob checksums.txt \
     --bundle checksums.txt.cosign.bundle \
-    --certificate-identity=https://github.com/go418/klone/.github/workflows/release.yml@refs/tags/v0.0.1-alpha.0 \
+    --certificate-identity=https://github.com/cert-manager/klone/.github/workflows/release.yml@refs/tags/v0.0.1-alpha.0 \
     --certificate-oidc-issuer=https://token.actions.githubusercontent.com

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/go418/klone
+module github.com/cert-manager/klone
 
 go 1.21.1
 

--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/go418/klone/cmd"
+	"github.com/cert-manager/klone/cmd"
 )
 
 func main() {

--- a/pkg/cache/clone.go
+++ b/pkg/cache/clone.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/go418/klone/pkg/mod"
+	"github.com/cert-manager/klone/pkg/mod"
 	cp "github.com/otiai10/copy"
 )
 

--- a/pkg/download/git/clone.go
+++ b/pkg/download/git/clone.go
@@ -8,7 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 
-	"github.com/go418/klone/pkg/mod"
+	"github.com/cert-manager/klone/pkg/mod"
 )
 
 type cleanup func()


### PR DESCRIPTION
I moved this tool to the cert-manager repo.