### PR TITLE
Replace manual parsing of head comments

### DIFF
--- a/pkg/mod/index_test.go
+++ b/pkg/mod/index_test.go
@@ -41,6 +41,7 @@ func Test_editKloneFile(t *testing.T) {
 			name: "Preserve comments",
 			initial: `# Test comment1
 # Test comment2
+
 targets:
   target1:
     - folder_name: Folder A
@@ -54,6 +55,7 @@ targets:
 			},
 			expected: `# Test comment1
 # Test comment2
+
 targets:
   target1:
     - folder_name: Folder A
@@ -68,6 +70,7 @@ targets:
 			name: "Sort targets (level 1)",
 			initial: `# Test comment1
 # Test comment2
+
 targets:
   target2:
     - folder_name: Folder A
@@ -87,6 +90,7 @@ targets:
 			},
 			expected: `# Test comment1
 # Test comment2
+
 targets:
   target1:
     - folder_name: Folder A
@@ -107,6 +111,7 @@ targets:
 			name: "Sort targets (level 2)",
 			initial: `# Test comment1
 # Test comment2
+
 targets:
   target1:
     - folder_name: Folder B
@@ -125,6 +130,7 @@ targets:
 			},
 			expected: `# Test comment1
 # Test comment2
+
 targets:
   target1:
     - folder_name: Folder A


### PR DESCRIPTION
This leaves more to the YAML parser so we have less chance of accidentally introducing a bug or security issue in our own logic.

Also adds preservation of footer comments as a bonus!

In addition, this fixes `klone init` and `klone add` which are currently broken on main when run in a directory with no `klone.yaml`. That bug was caused by the comment preservation logic!