### PR TITLE
Add command descriptions to all commands

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -4,12 +4,18 @@ import (
 	"path/filepath"
 
 	"github.com/cert-manager/klone/pkg/mod"
+
 	"github.com/spf13/cobra"
 )
 
 func NewAddCommand() *cobra.Command {
 	cmds := &cobra.Command{
-		Use:  "add [DST_PATH] [DST_FOLDER_NAME] [REPO_URL] [REPO_REF] [REPO_FOLDER]",
+		Use:   "add [DST_PATH] [DST_FOLDER_NAME] [REPO_URL] [REPO_REF] [REPO_FOLDER]",
+		Short: "Add a new target to sync from an upstream git repository",
+		Example: `Sync the 'logo' directory from the main branch of the cert-manager
+community repository to the local directory ./a/b
+
+klone add a b https://github.com/cert-manager/community.git main logo`,
 		Args: cobra.ExactArgs(5),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			workDirPath, err := filepath.Abs(".")

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -6,7 +6,29 @@ import (
 
 func NewCommand() *cobra.Command {
 	cmds := &cobra.Command{
-		Use: "klone",
+		Use:   "klone",
+		Short: "Clone folders from a git repo locally",
+		Long: `Clone folders from an upstream git repo locally
+
+Klone takes a config file as input and copies folders from listed upstream
+git repositories to the local directory.
+
+To get started, run "klone init" which will create a barebones klone.yaml file
+which does nothing.
+
+To add a target for kloning, use "klone add", e.g.:
+
+klone add example myfolder https://github.com/cert-manager/community.git main logo
+
+This will add an entry to klone.yaml which fetches the latest cert-manager
+logo from the community repo and stores it in example/myfolder.
+
+Finally, we can run "klone sync" to actually perform the checkout. If you ran
+the "klone add" command above, you'll see that the "example/myfolder" directory
+has been populated from the remote git repository.
+
+If there's an upstream update later, "klone upgrade" will fetch the latest
+revision for the upstream and check out the results locally.`,
 	}
 
 	cmds.AddCommand(NewInitCommand())

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -4,13 +4,15 @@ import (
 	"path/filepath"
 
 	"github.com/cert-manager/klone/pkg/mod"
+
 	"github.com/spf13/cobra"
 )
 
 func NewInitCommand() *cobra.Command {
 	cmds := &cobra.Command{
-		Use:  "init",
-		Args: cobra.ExactArgs(0),
+		Use:   "init",
+		Short: "Initialise a new klone.yaml file and exit",
+		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			workDirPath, err := filepath.Abs(".")
 			if err != nil {

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -8,13 +8,15 @@ import (
 	"github.com/cert-manager/klone/pkg/cache"
 	"github.com/cert-manager/klone/pkg/download/git"
 	"github.com/cert-manager/klone/pkg/mod"
+
 	"github.com/spf13/cobra"
 )
 
 func NewSyncCommand() *cobra.Command {
 	cmds := &cobra.Command{
-		Use:  "sync",
-		Args: cobra.ExactArgs(0),
+		Use:   "sync",
+		Short: "Ensure the local state of targets matches upstream",
+		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			workDirPath, err := filepath.Abs(".")
 			if err != nil {

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -8,13 +8,15 @@ import (
 	"github.com/cert-manager/klone/pkg/cache"
 	"github.com/cert-manager/klone/pkg/download/git"
 	"github.com/cert-manager/klone/pkg/mod"
+
 	"github.com/spf13/cobra"
 )
 
 func NewUpgradeCommand() *cobra.Command {
 	cmds := &cobra.Command{
-		Use:  "upgrade",
-		Args: cobra.ExactArgs(0),
+		Use:   "upgrade",
+		Args:  cobra.ExactArgs(0),
+		Short: "Update all hashes to the latest upstream available and sync",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			workDirPath, err := filepath.Abs(".")
 			if err != nil {


### PR DESCRIPTION
This is fluff but I figured it would be helpful!

New output of `klone`:

```text
Clone folders from an upstream git repo locally

Klone takes a config file as input and copies folders from listed upstream
git repositories to the local directory.

To get started, run "klone init" which will create a barebones klone.yaml file
which does nothing.

To add a target for kloning, use "klone add", e.g.:

klone add example myfolder https://github.com/cert-manager/community.git main logo

This will add an entry to klone.yaml which fetches the latest cert-manager
logo from the community repo and stores it in example/myfolder.

Finally, we can run "klone sync" to actually perform the checkout. If you ran
the "klone add" command above, you'll see that the "example/myfolder" directory
has been populated from the remote git repository.

If there's an upstream update later, "klone upgrade" will fetch the latest
revision for the upstream and check out the results locally.

Usage:
  klone [command]

Available Commands:
  add         Add a new target to sync from an upstream git repository
  completion  Generate the autocompletion script for the specified shell
  help        Help about any command
  init        Initialise a new klone.yaml file and exit
  sync        Ensure the local state of targets matches upstream
  upgrade     Update all hashes to the latest upstream available and sync

Flags:
  -h, --help   help for klone

Use "klone [command] --help" for more information about a command.
```