### PR TITLE
Make it possible to pin to a commit using the add command

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -10,13 +10,15 @@ import (
 
 func NewAddCommand() *cobra.Command {
 	cmds := &cobra.Command{
-		Use:   "add [DST_PATH] [DST_FOLDER_NAME] [REPO_URL] [REPO_REF] [REPO_FOLDER]",
+		Use:   "add dst_path dst_folder_name repo_url repo_path repo_ref [repo_hash]",
 		Short: "Add a new target to sync from an upstream git repository",
 		Example: `Sync the 'logo' directory from the main branch of the cert-manager
 community repository to the local directory ./a/b
 
-klone add a b https://github.com/cert-manager/community.git main logo`,
-		Args: cobra.ExactArgs(5),
+  klone add a b https://github.com/cert-manager/community.git logo main
+    or with pinned commit hash:
+  klone add a b https://github.com/cert-manager/community.git logo main 9f0ea0341816665feadcdcfb7744f4245604ab28`,
+		Args: cobra.RangeArgs(5, 6),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			workDirPath, err := filepath.Abs(".")
 			if err != nil {
@@ -28,13 +30,19 @@ klone add a b https://github.com/cert-manager/community.git main logo`,
 			dstPath := args[0]
 			dstFolderName := args[1]
 			repoURL := args[2]
-			ref := args[3]
-			srcFolder := args[4]
+			repoPath := args[3]
+			repoRef := args[4]
+
+			repoHash := ""
+			if len(args) == 6 {
+				repoHash = args[5]
+			}
 
 			return wrkDir.AddTarget(dstPath, dstFolderName, mod.KloneSource{
 				RepoURL:  repoURL,
-				RepoRef:  ref,
-				RepoPath: srcFolder,
+				RepoPath: repoPath,
+				RepoRef:  repoRef,
+				RepoHash: repoHash,
 			})
 		},
 	}

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -18,7 +18,7 @@ which does nothing.
 
 To add a target for kloning, use "klone add", e.g.:
 
-klone add example myfolder https://github.com/cert-manager/community.git main logo
+klone add example myfolder https://github.com/cert-manager/community.git logo main
 
 This will add an entry to klone.yaml which fetches the latest cert-manager
 logo from the community repo and stores it in example/myfolder.

--- a/test-e2e.sh
+++ b/test-e2e.sh
@@ -18,7 +18,15 @@ pushd "$temp_dir"
 mkdir -p a/b
 touch a/SHOULD_NOT_BE_DELETED
 touch a/b/SHOULD_BE_DELETED
-"$klone_binary" add a/b c/d https://github.com/cert-manager/community.git main logo
+"$klone_binary" add a/b c/d https://github.com/cert-manager/community.git logo main
+"$klone_binary" add a/b e https://github.com/cert-manager/community.git logo main 9f0ea0341816665feadcdcfb7744f4245604ab28
 "$klone_binary" sync
+if [ -f a/SHOULD_NOT_BE_DELETED ] && [ ! -f a/b/SHOULD_BE_DELETED ]; then
+  echo "Test passed"
+else
+  echo "Test failed"
+  exit 1
+fi
+cat klone.yaml
 tree -a
 popd


### PR DESCRIPTION
Adds an optional argument to `klone add`, which allows you to specify the hash.