### PR TITLE
Fix bug in rsync command, we were not removing files that exist in the destination dir but not in the source

### DIFF
--- a/pkg/cache/clone.go
+++ b/pkg/cache/clone.go
@@ -82,7 +82,7 @@ func CloneWithCache(
 		return err
 	}
 
-	if err := runRsyncCmd(cachePath, os.Stdout, os.Stderr, "-aEq", ".", destPath); err != nil {
+	if err := runRsyncCmd(cachePath, os.Stdout, os.Stderr, "-aEq", "--delete", ".", destPath); err != nil {
 		return err
 	}
 

--- a/test-e2e.sh
+++ b/test-e2e.sh
@@ -15,9 +15,10 @@ temp_dir=$(mktemp -d)
 trap '{ rm -rf "$temp_dir"; echo "> Deleted temp dir $temp_dir"; }' EXIT
 pushd "$temp_dir"
 "$klone_binary" init
-mkdir -p a/b
+mkdir -p a/b/e
 touch a/SHOULD_NOT_BE_DELETED
 touch a/b/SHOULD_BE_DELETED
+touch a/b/e/SHOULD_BE_DELETED
 "$klone_binary" add a/b c/d https://github.com/cert-manager/community.git logo main
 "$klone_binary" add a/b e https://github.com/cert-manager/community.git logo main 9f0ea0341816665feadcdcfb7744f4245604ab28
 "$klone_binary" sync


### PR DESCRIPTION
Adds the missing `--delete` rsync flag.