### PR TITLE
devel: Add makefile for development, target stable go in GHA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,18 +18,26 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
+      - id: goreleaser-version
+        run: |
+          make print-goreleaser-version >> "$GITHUB_OUTPUT"
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # this is important, otherwise it won't checkout the full tree (i.e. no previous tags)
-      - uses: actions/setup-go@v4
+
+      - uses: actions/setup-go@v5
         with:
-          go-version: 1.21
+          go-version: stable
           cache: true
+
       - uses: sigstore/cosign-installer@v3.1.2         # installs cosign
+
       - uses: anchore/sbom-action/download-syft@v0.14.3 # installs syft
+
       - uses: goreleaser/goreleaser-action@v5          # run goreleaser
         with:
-          version: latest
+          version: ${{ steps.goreleaser-version.outputs.goreleaser_version }}
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,18 +12,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
-          go-version: 1.21
+          go-version: stable
           cache: true
-      - run: go test -v ./...
+      - run: make test
 
   e2e:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
-          go-version: 1.21
+          go-version: stable
           cache: true
-      - run: ./test-e2e.sh
+      - run: make test-e2e

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode/
 dist/
+_bin

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,3 +1,5 @@
+version: 2
+
 builds:
   - env:
       - CGO_ENABLED=0
@@ -41,7 +43,8 @@ signs:
 
 archives:
   - name_template: "{{.Binary}}_{{.Os}}_{{.Arch}}"
-    format: binary
+    formats:
+      - binary
 
 changelog:
   sort: asc

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -49,3 +49,4 @@ changelog:
     exclude:
       - '^docs:'
       - '^test:'
+      - '^devel:'

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,54 @@
+# Copyright 2023 The cert-manager Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# For details on some of these "prelude" settings, see:
+# https://clarkgrubb.com/makefile-style-guide
+MAKEFLAGS += --warn-undefined-variables --no-builtin-rules
+SHELL := /usr/bin/env bash
+.SHELLFLAGS := -uo pipefail -c
+.DEFAULT_GOAL := help
+.DELETE_ON_ERROR:
+.SUFFIXES:
+FORCE:
+
+bin_dir := _bin
+
+sources := $(shell find ./cmd ./pkg -name "*.go")
+
+goreleaser_version := v2.6.1
+goreleaser := $(bin_dir)/goreleaser-$(goreleaser_version)/goreleaser
+
+.PHONY: build
+build: $(bin_dir)/klone
+
+.PHONY: test
+test:
+	go test ./...
+
+.PHONY: test-e2e
+test-e2e: $(bin_dir)/klone
+	./test-e2e.sh $<
+
+$(bin_dir)/klone: $(sources) .goreleaser.yaml | $(goreleaser) $(bin_dir)
+	$(goreleaser) build --single-target --snapshot --clean --output $@
+
+$(goreleaser): | $(bin_dir)/goreleaser-$(goreleaser_version)
+	GOBIN=$(shell pwd)/$| go install github.com/goreleaser/goreleaser/v2@$(goreleaser_version)
+
+.PHONY: print-goreleaser-version
+print-goreleaser-version:
+	@echo "goreleaser_version=$(goreleaser_version)"
+
+$(bin_dir) $(bin_dir)/goreleaser-$(goreleaser_version):
+	mkdir -p $@

--- a/test-e2e.sh
+++ b/test-e2e.sh
@@ -1,33 +1,57 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-set -e
+set -eu -o pipefail
 
-go build -o ./dist/klone_test .
-klone_binary=$(realpath ./dist/klone_test)
+klone_binary=$(realpath $1)
 
-# Test that the sync command works for the example directory
+# 1. Test that the sync command works for the example directory
+
 pushd ./example
 "$klone_binary" sync
 popd
 
-# Create a temp directory and test that the init, add, and sync commands work
+# 2. Create a temp directory and test that the init, add, and sync commands work
+
 temp_dir=$(mktemp -d)
 trap '{ rm -rf "$temp_dir"; echo "> Deleted temp dir $temp_dir"; }' EXIT
+
 pushd "$temp_dir"
+
 "$klone_binary" init
+
 mkdir -p a/b/e
+
 touch a/SHOULD_NOT_BE_DELETED
 touch a/b/SHOULD_BE_DELETED
 touch a/b/e/SHOULD_BE_DELETED
+
 "$klone_binary" add a/b c/d https://github.com/cert-manager/community.git logo main
+
 "$klone_binary" add a/b e https://github.com/cert-manager/community.git logo main 9f0ea0341816665feadcdcfb7744f4245604ab28
+
 "$klone_binary" sync
-if [ -f a/SHOULD_NOT_BE_DELETED ] && [ ! -f a/b/SHOULD_BE_DELETED ]; then
-  echo "Test passed"
-else
-  echo "Test failed"
-  exit 1
+
+if [ ! -f a/SHOULD_NOT_BE_DELETED ]; then
+	echo "Test failed: a/SHOULD_NOT_BE_DELETED not found"
+	exit 1
 fi
+
+if  [ -f a/b/SHOULD_BE_DELETED ]; then
+	echo "Test failed: a/b/SHOULD_BE_DELETED was found"
+	exit 1
+fi
+
+if  [ -f a/b/e/SHOULD_BE_DELETED ]; then
+	echo "Test failed: a/b/e/SHOULD_BE_DELETED was found"
+	exit 1
+fi
+
+echo "> Test succeeded"
+
+echo "> klone.yaml"
 cat klone.yaml
+
+echo "> Directory structure"
 tree -a
+
 popd


### PR DESCRIPTION
This makes local builds close to released builds (i.e. using goreleaser), and bumps the version of go we use to test and release to a stable version.

For this small tool, it seems reasonable to target the latest stable Go version rather than fixing a specific version.