### PR TITLE
feat: Add envvar for retrying git operations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,9 @@
 module github.com/cert-manager/klone
 
-go 1.21.1
+go 1.23
 
 require (
+	github.com/cenkalti/backoff/v5 v5.0.1
 	github.com/rogpeppe/go-internal v1.11.0
 	github.com/spf13/cobra v1.7.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/cenkalti/backoff/v5 v5.0.1 h1:kGZdCHH1+eW+Yd0wftimjMuhg9zidDvNF5aGdnkkb+U=
+github.com/cenkalti/backoff/v5 v5.0.1/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=

--- a/pkg/cache/clone.go
+++ b/pkg/cache/clone.go
@@ -18,6 +18,7 @@ func calculateCacheKey(src mod.KloneSource) string {
 }
 
 func getCacheDir() (string, error) {
+	// TODO: add centralized config management defining env vars + maybe a global config file for klone
 	if cacheDir := os.Getenv("KLONE_CACHE_DIR"); cacheDir != "" {
 		return filepath.Abs(filepath.Clean(cacheDir))
 	}

--- a/pkg/download/git/clone.go
+++ b/pkg/download/git/clone.go
@@ -61,6 +61,7 @@ func runGitCmd(ctx context.Context, root string, stdout io.Writer, stderr io.Wri
 }
 
 func getRetryCount() uint {
+	// TODO: add centralized config management defining env vars + maybe a global config file for klone
 	retryCountRaw := os.Getenv("KLONE_GIT_RETRY_ATTEMPTS")
 	if retryCountRaw == "" {
 		return 1


### PR DESCRIPTION
Based loosely on similar code we [recently added to cmrel](https://github.com/cert-manager/release/pull/195).

Context: Behind the CyberArk corporate proxy, we often see git failures if many clone / pull operations are performed in rapid succession, which with klone is a common pattern.

This PR adds a simple retry mechanism, aiming to do the simplest possible thing to reduce flakes in our environments. This also uses a static delay between retries rather than any fancier solution.

The variable is called `KLONE_GIT_RETRY_ATTEMPTS`