### PR TITLE
bug: only try to print goreleaser version after checkout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,13 +18,13 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - id: goreleaser-version
-        run: |
-          make print-goreleaser-version >> "$GITHUB_OUTPUT"
-
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # this is important, otherwise it won't checkout the full tree (i.e. no previous tags)
+
+      - id: goreleaser-version
+        run: |
+          make print-goreleaser-version >> "$GITHUB_OUTPUT"
 
       - uses: actions/setup-go@v5
         with:


### PR DESCRIPTION
This caused my first attempt to release v0.2.0 to fail: https://github.com/cert-manager/klone/actions/runs/13203791605/job/36861984715